### PR TITLE
Feature/zoo wall map edge crash fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ name = "test"
 path = "src/debug.rs"
 
 [features]
-default = ["bf_registry", "console", "ini", "zt_world_mgr", "bf_resource_mgr", "ztui"]
+default = ["bf_registry", "console", "ini", "zt_world_mgr", "bf_resource_mgr", "ztui", "bugfix"]
 console = []
 ini = []
 bf_registry = []
@@ -33,3 +33,4 @@ bf_resource_mgr = []
 zt_world_mgr = []
 zoo_logging = []
 ztui = []
+bugfix = []

--- a/src/bugfix.rs
+++ b/src/bugfix.rs
@@ -1,0 +1,16 @@
+
+use tracing::info;
+
+use crate::debug_dll::{get_from_memory, save_to_protected_memory};
+
+const ZOOWALL_MAP_EDGE_CRASH_ADDRESS: u32 = 0x050b260;
+
+pub fn init() {
+    fix_zoowall_map_edge_crash();
+}
+
+
+fn fix_zoowall_map_edge_crash() {
+    // We change a jump address to fix a bug trying access a null pointer
+    save_to_protected_memory(ZOOWALL_MAP_EDGE_CRASH_ADDRESS, 0xfffffcfeu32 as i32);
+}

--- a/src/bugfix.rs
+++ b/src/bugfix.rs
@@ -1,12 +1,19 @@
 
+use std::arch::global_asm;
+
 use tracing::info;
 
-use crate::debug_dll::{get_from_memory, save_to_protected_memory};
+use crate::debug_dll::{get_from_memory, save_to_protected_memory, patch_nop};
 
 const ZOOWALL_MAP_EDGE_CRASH_ADDRESS: u32 = 0x050b260;
 
+const ZOOFENCE_ONE_TILE_FROM_MAP_EDGE_CRASH_ADDRESS_1: u32 = 0x4a1fc0;
+const ZOOFENCE_ONE_TILE_FROM_MAP_EDGE_CRASH_ADDRESS_2: u32 = 0x4a1fe7;
+// const ZOOFENCE_ONE_TILE_FROM_MAP_EDGE_CRASH_ADDRESS_1: u32 = ;
+
 pub fn init() {
     fix_zoowall_map_edge_crash();
+    fix_fence_one_tile_from_map_edge_crash()
 }
 
 
@@ -14,3 +21,34 @@ fn fix_zoowall_map_edge_crash() {
     // We change a jump address to fix a bug trying access a null pointer
     save_to_protected_memory(ZOOWALL_MAP_EDGE_CRASH_ADDRESS, 0xfffffcfeu32 as i32);
 }
+
+fn fix_fence_one_tile_from_map_edge_crash() {
+    // This changes an if statement to cover the entire inner loop
+    save_to_protected_memory::<u8>(ZOOFENCE_ONE_TILE_FROM_MAP_EDGE_CRASH_ADDRESS_1, 0x45);
+    // The above change makes the second if statement redundant so we can add in a check for the null pointer
+    save_to_protected_memory::<u8>(ZOOFENCE_ONE_TILE_FROM_MAP_EDGE_CRASH_ADDRESS_2, 0x85);
+    save_to_protected_memory::<u8>(ZOOFENCE_ONE_TILE_FROM_MAP_EDGE_CRASH_ADDRESS_2 + 1, 0xC0);
+    patch_nop(ZOOFENCE_ONE_TILE_FROM_MAP_EDGE_CRASH_ADDRESS_2 + 2);
+}
+
+// Leaving this in incase future bugfixes require inline assembly
+
+// pub mod fence_crash_asm {
+//     global_asm!(r#"
+//         .global fence_crash_trmp
+//       :
+//         call DWORD PTR ds:0x40fa92
+//         TEST EAX, EAX
+//         JZ 0x01
+//         JMP DWORD PTR 
+//         JMP DWORD PTR ds:<past original if>
+
+//         jmp back to original if
+//     "#);
+// }
+
+// the symbols `foo` and `bar` are global, no matter where
+// `global_asm!` was used.
+// extern "C" {
+//     fn fence_crash_trmp();
+// }

--- a/src/debug_dll.rs
+++ b/src/debug_dll.rs
@@ -356,7 +356,7 @@ pub fn patch_nop(address: u32) {
         {
             let mut old_protect: u32 = 0;
             VirtualProtect(address as *mut _, 1, PAGE_EXECUTE_READWRITE, &mut old_protect);
-            ptr::write(address as *mut _, 0x90);
+            ptr::write(address as *mut _, 0x90u8);
             VirtualProtect(address as *mut _, 1, old_protect, &mut old_protect);
         }
     }

--- a/src/debug_dll.rs
+++ b/src/debug_dll.rs
@@ -61,6 +61,17 @@ pub fn save_to_memory<T>(address: u32, value: T) {
     unsafe { ptr::write(address as *mut T, value)};
 }
 
+pub fn save_to_protected_memory<T>(address: u32, value: T) {
+    unsafe {
+        {
+            let mut old_protect: u32 = 0;
+            VirtualProtect(address as *mut _, std::mem::size_of::<T>() as usize, PAGE_EXECUTE_READWRITE, &mut old_protect);
+            ptr::write(address as *mut _, value);
+            VirtualProtect(address as *mut _, std::mem::size_of::<T>() as usize, old_protect, &mut old_protect);
+        }
+    }
+}
+
 pub fn log_debug_ini_memory_values() {
     let send_debugger: bool = get_from_memory::<bool>(SEND_DEBUGGER_ADDRESS);
     debug_logger(&format!("send_debugger: {}", send_debugger));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ mod resource_manager;
 
 mod ztui;
 
+mod bugfix;
+
 #[cfg(target_os = "windows")]
 use winapi::um::winnt::{DLL_PROCESS_ATTACH, DLL_PROCESS_DETACH, DLL_THREAD_ATTACH, DLL_THREAD_DETACH};
 
@@ -188,6 +190,11 @@ extern "system" fn DllMain(module: u8, reason: u32, _reserved: u8) -> i32 {
             if cfg!(feature = "zt_world_mgr") {
                 info!("Feature 'zt_world_mgr' enabled");
                 ztworldmgr::init();
+            }
+
+            if cfg!(feature = "bugfix") {
+                info!("Feature 'bugfix' enabled");
+                bugfix::init();
             }
         }
         DLL_PROCESS_DETACH => {


### PR DESCRIPTION
Merge fixes for deleting zoowall on edge of map and maintenance worker repairing an exhibit fence 1 tile away from the edge of the map