### PR TITLE
EntityTypes Hooks Implementation

### DIFF
--- a/src/bfentitytype.rs
+++ b/src/bfentitytype.rs
@@ -1,0 +1,314 @@
+use crate::debug_dll::{get_from_memory, get_string_from_memory};
+use crate::add_to_command_register;
+
+use tracing::info;
+use std::collections::HashMap;
+use std::fmt;
+use num_enum::FromPrimitive;
+
+trait BFEntityType {
+    fn get_ncolors() -> u32; // 0x038
+    fn set_ncolors(ncolors: u32); // 0x038
+    fn get_icon_zoom() -> bool; // 0x050
+    fn set_icon_zoom(icon_zoom: bool); // 0x050
+    fn get_expansion_id() -> bool; // 0x054
+    fn set_expansion_id(expansion_id: bool); // 0x054
+    fn get_movable() -> bool; // 0x055
+    fn set_movable(movable: bool); // 0x055
+    fn get_walkable() -> bool; // 0x056
+    fn set_walkable(walkable: bool); // 0x056
+    fn get_walkable_by_tall() -> bool; // 0x057
+    fn set_walkable_by_tall(walkable_by_tall: bool); // 0x057
+    fn get_rubbleable() -> bool; // 0x059
+    fn set_rubbleable(rubbleable: bool); // 0x059
+    fn get_use_numbers_in_name() -> bool; // 0x05B
+    fn set_use_numbers_in_name(use_numbers_in_name: bool); // 0x05B
+    fn get_uses_real_shadows() -> bool; // 0x05C
+    fn set_uses_real_shadows(uses_real_shadows: bool); // 0x05C
+    fn get_has_shadow_images() -> bool; // 0x05D
+    fn set_has_shadow_images(has_shadow_images: bool); // 0x05D
+    fn get_force_shadow_black() -> bool; // 0x05E
+    fn set_force_shadow_black(force_shadow_black: bool); // 0x05E
+    fn get_draws_late() -> bool; // 0x060 <---- Might need double checking, not available in viewing canopies
+    fn set_draws_late(draws_late: bool); // 0x060
+    fn get_height() -> u32; // 0x064
+    fn set_height(height: u32); // 0x064
+    fn get_depth() -> u32; // 0x068
+    fn set_depth(depth: u32); // 0x068
+    fn get_has_underwater_section() -> bool; // 0x06C
+    fn set_has_underwater_section(has_underwater_section: bool); // 0x06C
+    fn get_is_transient() -> bool; // 0x06D
+    fn set_is_transient(is_transient: bool); // 0x06D
+    fn get_uses_placement_cube() -> bool; // 0x06E
+    fn set_uses_placement_cube(uses_placement_cube: bool); // 0x06E
+    fn get_show() -> bool; // 0x06F
+    fn set_show(show: bool); // 0x06F
+    fn get_hit_threshold() -> u32; // 0x070
+    fn set_hit_threshold(hit_threshold: u32); // 0x070
+    fn get_avoid_edges() -> bool; // 0x074
+    fn set_avoid_edges(avoid_edges: bool); // 0x074
+    fn get_type_name() -> String; // 0x0A4, 0x0A8
+    fn set_type_name(type_name: String); // 0x0A4, 
+    fn get_codename() -> String; // 0x098, 0x09C
+    fn set_codename(codename: String); // 0x098, 0x09C
+    fn get_footprintx() -> u32; // 0x0B4
+    fn set_footprintx(footprintx: u32); // 0x0B4
+    fn get_footprinty() -> u32; // 0x0B8
+    fn set_footprinty(footprinty: u32); // 0x0B8
+    fn get_footprintz() -> u32; // 0x0BC
+    fn set_footprintz(footprintz: u32); // 0x0BC
+    fn get_placement_footprintx() -> u32; // 0x0C0
+    fn set_placement_footprintx(placement_footprintx: u32); // 0x0C0
+    fn get_placement_footprinty() -> u32; // 0x0C4
+    fn set_placement_footprinty(placement_footprinty: u32); // 0x0C4
+    fn get_placement_footprintz() -> u32; // 0x0C8
+    fn set_placement_footprintz(placement_footprintz: u32); // 0x0C8
+    fn get_available_at_startup() -> bool; // 0x0CC
+    fn set_available_at_startup(available_at_startup: bool); // 0x0CC
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct EntityType {
+    this: u32,
+}
+
+impl BFEntityType for EntityType {
+    fn this(ptr : u32) -> u32 {
+        EntityType {
+            this: ptr
+        }
+    }
+
+    fn get_ncolors() -> u32 {
+        get_from_memory::<u32>(this + 0x038)
+    }
+
+    fn set_ncolors(ncolors: u32) {
+        get_from_memory::<u32>(this + 0x038) = ncolors;
+    }
+
+    fn get_icon_zoom() -> bool {
+        get_from_memory::<bool>(this + 0x050)
+    }
+
+    fn set_icon_zoom(icon_zoom: bool) {
+        get_from_memory::<bool>(this + 0x050) = icon_zoom;
+    }
+
+    fn get_expansion_id() -> bool {
+        get_from_memory::<bool>(this + 0x054)
+    }
+
+    fn set_expansion_id(expansion_id: bool) {
+        get_from_memory::<bool>(this + 0x054) = expansion_id;
+    }
+
+    fn get_movable() -> bool {
+        get_from_memory::<bool>(this + 0x055)
+    }
+
+    fn set_movable(movable: bool) {
+        get_from_memory::<bool>(this + 0x055) = movable;
+    }
+
+    fn get_walkable() -> bool {
+        get_from_memory::<bool>(this + 0x056)
+    }
+
+    fn set_walkable(walkable: bool) {
+        get_from_memory::<bool>(this + 0x056) = walkable;
+    }
+
+    fn get_walkable_by_tall() -> bool {
+        get_from_memory::<bool>(this + 0x057)
+    }
+
+    fn set_walkable_by_tall(walkable_by_tall: bool) {
+        get_from_memory::<bool>(this + 0x057) = walkable_by_tall;
+    }
+
+    fn get_rubbleable() -> bool {
+        get_from_memory::<bool>(this + 0x059)
+    }
+
+    fn set_rubbleable(rubbleable: bool) {
+        get_from_memory::<bool>(this + 0x059) = rubbleable;
+    }
+
+    fn get_use_numbers_in_name() -> bool {
+        get_from_memory::<bool>(this + 0x05B)
+    }
+
+    fn set_use_numbers_in_name(use_numbers_in_name: bool) {
+        get_from_memory::<bool>(this + 0x05B) = use_numbers_in_name;
+    }
+
+    fn get_uses_real_shadows() -> bool {
+        get_from_memory::<bool>(this + 0x05C)
+    }
+
+    fn set_uses_real_shadows(uses_real_shadows: bool) {
+        get_from_memory::<bool>(this + 0x05C) = uses_real_shadows;
+    }
+
+    fn get_has_shadow_images() -> bool {
+        get_from_memory::<bool>(this + 0x05D)
+    }
+
+    fn set_has_shadow_images(has_shadow_images: bool) {
+        get_from_memory::<bool>(this + 0x05D) = has_shadow_images;
+    }
+
+    fn get_force_shadow_black() -> bool {
+        get_from_memory::<bool>(this + 0x05E)
+    }
+
+    fn set_force_shadow_black(force_shadow_black: bool) {
+        get_from_memory::<bool>(this + 0x05E) = force_shadow_black;
+    }
+
+    fn get_draws_late() -> bool {
+        get_from_memory::<bool>(this + 0x060)
+    }
+
+    fn set_draws_late(draws_late: bool) {
+        get_from_memory::<bool>(this + 0x060) = draws_late;
+    }
+
+    fn get_height() -> u32 {
+        get_from_memory::<u32>(this + 0x064)
+    }
+
+    fn set_height(height: u32) {
+        get_from_memory::<u32>(this + 0x064) = height;
+    }
+
+    fn get_depth() -> u32 {
+        get_from_memory::<u32>(this + 0x068)
+    }
+
+    fn set_depth(depth: u32) {
+        get_from_memory::<u32>(this + 0x068) = depth;
+    }
+
+    fn get_has_underwater_section() -> bool {
+        get_from_memory::<bool>(this + 0x06C)
+    }
+
+    fn set_has_underwater_section(has_underwater_section: bool) {
+        get_from_memory::<bool>(this + 0x06C) = has_underwater_section;
+    }
+
+    fn get_is_transient() -> bool {
+        get_from_memory::<bool>(this + 0x06D)
+    }
+
+    fn set_is_transient(is_transient: bool) {
+        get_from_memory::<bool>(this + 0x06D) = is_transient;
+    }
+
+    fn get_uses_placement_cube() -> bool {
+        get_from_memory::<bool>(this + 0x06E)
+    }
+
+    fn set_uses_placement_cube(uses_placement_cube: bool) {
+        get_from_memory::<bool>(this + 0x06E) = uses_placement_cube;
+    }
+
+    fn get_show() -> bool {
+        get_from_memory::<bool>(this + 0x06F)
+    }
+
+    fn set_show(show: bool) {
+        get_from_memory::<bool>(this + 0x06F) = show;
+    }
+
+    fn get_hit_threshold() -> u32 {
+        get_from_memory::<u32>(this + 0x070)
+    }
+
+    fn set_hit_threshold(hit_threshold: u32) {
+        get_from_memory::<u32>(this + 0x070) = hit_threshold;
+    }
+
+    fn get_avoid_edges() -> bool {
+        get_from_memory::<bool>(this + 0x074)
+    }
+
+    fn set_avoid_edges(avoid_edges: bool) {
+        get_from_memory::<bool>(this + 0x074) = avoid_edges;
+    }
+
+    fn get_type_name() -> String {
+        get_string_from_memory(this + 0x0A4)
+    }
+
+    fn set_type_name(type_name: String) {
+        get_from_memory::<String>(this + 0x0A4) = type_name;
+    }
+
+    fn get_codename() -> String {
+        get_string_from_memory(this + 0x098)
+    }
+
+    fn set_codename(codename: String) {
+        get_from_memory::<String>(this + 0x098) = codename;
+    }
+
+    fn get_footprintx() -> u32 {
+        get_from_memory::<u32>(this + 0x0B4)
+    }
+
+    fn set_footprintx(footprintx: u32) {
+        get_from_memory::<u32>(this + 0x0B4) = footprintx;
+    }
+
+    fn get_footprinty() -> u32 {
+        get_from_memory::<u32>(this + 0x0B8)
+    }
+
+    fn set_footprinty(footprinty: u32) {
+        get_from_memory::<u32>(this + 0x0B8) = footprinty;
+    }
+
+    fn get_footprintz() -> u32 {
+        get_from_memory::<u32>(this + 0x0BC)
+    }
+
+    fn set_footprintz(footprintz: u32) {
+        get_from_memory::<u32>(this + 0x0BC) = footprintz;
+    }
+
+    fn get_placement_footprintx() -> u32 {
+        get_from_memory::<u32>(this + 0x0C0)
+    }
+
+    fn set_placement_footprintx(placement_footprintx: u32) {
+        get_from_memory::<u32>(this + 0x0C0) = placement_footprintx;
+    }
+
+    fn get_placement_footprinty() -> u32 {
+        get_from_memory::<u32>(this + 0x0C4)
+    }
+
+    fn set_placement_footprinty(placement_footprinty: u32) {
+        get_from_memory::<u32>(this + 0x0C4) = placement_footprinty;
+    }
+
+    fn get_placement_footprintz() -> u32 {
+        get_from_memory::<u32>(this + 0x0C8)
+    }
+
+    fn set_placement_footprintz(placement_footprintz: u32) {
+        get_from_memory::<u32>(this + 0x0C8) = placement_footprintz;
+    }
+
+    fn get_available_at_startup() -> bool {
+        get_from_memory::<bool>(this + 0x0CC)
+    }
+
+    fn set_available_at_startup(available_at_startup: bool) {
+        get_from_memory::<bool>(this + 0x0CC) = available_at_startup;
+    }
+}

--- a/src/bfentitytype.rs
+++ b/src/bfentitytype.rs
@@ -34,11 +34,7 @@ struct BFEntityType {
     show: bool, // 0x06F
     hit_threshold: u32, // 0x070
     avoid_edges: bool, // 0x074
-    pad8: [u8; 0x098 - 0x075], // -- padding: 27 bytes
-    codename: String, // 0x098
-    pad9: [u8; 0x0A4 - 0x09C], // -- padding: 8 bytes
-    type_name: String, // 0x0A4
-    pad10: [u8; 0x0B0 - 0x0A8], // -- padding: 8 bytes
+    pad10: [u8; 0x0B4 - 0x075], // -- padding: 47 bytes
     footprintx: u32, // 0x0B4
     footprinty: u32, // 0x0B8
     footprintz: u32, // 0x0BC
@@ -52,18 +48,39 @@ struct BFEntityType {
 
 impl BFEntityType {
     // returns the instance of the ZTGameMgr struct
-    unsafe fn new(ptr: *mut BFEntityType) -> &'static mut BFEntityType {
-        &mut *ptr
+    fn new(address: u32) -> Option<&'static mut BFEntityType> {
+        unsafe {
+            // get the pointer to the ZTGameMgr instance    
+            let ptr = get_from_memory::<*mut BFEntityType>(address);
+    
+            // is pointer not null
+            if !ptr.is_null() {
+                Some(&mut *ptr)
+            } 
+            else {
+                // pointer is null
+                None
+            }
+        }
+    }
+
+    fn get_codename(&self) -> String {
+        let obj_ptr = self as *const BFEntityType as u32;
+        get_string_from_memory(get_from_memory::<u32>(obj_ptr + 0x098))
+    }
+
+    fn get_type_name(&self) -> String {
+        let obj_ptr = self as *const BFEntityType as u32;
+        get_string_from_memory(get_from_memory::<u32>(obj_ptr + 0x0A4))
     }
 }
 pub fn command_selected_type(_args: Vec<&str>) -> Result<String, &'static str> {
     
     let entity_type_address = get_selected_entity_type();
-    let entity_type_ptr = get_from_memory::<*mut BFEntityType>(entity_type_address);
-    if entity_type_ptr == std::ptr::null_mut() {
+    if entity_type_address == 0 {
         return Err("No entity selected");
     }
-    let entity_type = unsafe {BFEntityType::new(entity_type_ptr)};
+    let entity_type = BFEntityType::new(entity_type_address).unwrap();
     if _args.len() == 0 {
         return Ok(format!("Entity type at address {:#x}", entity_type_address));
     }
@@ -71,38 +88,38 @@ pub fn command_selected_type(_args: Vec<&str>) -> Result<String, &'static str> {
 
         info!("Printing configuration for entity type at address {:#x}", entity_type_address);
     
-        Ok(format!("\n\n[Details]\nEntityType: {:#x}\nType Name: {}\nCodename: {}\n\n[Printed configuration]\nncolors: {}\ncIconZoom: {}\ncExpansionID: {}\ncMovable: {}\ncWalkable: {}\ncWalkableByTall: {}\ncRubbleable: {}\ncUseNumbersInName: {}\ncUsesRealShadows: {}\ncHasShadowImages: {}\ncForceShadowBlack: {}\ncDrawsLate: {}\ncHeight: {}\ncDepth: {}\ncHasUnderwaterSection: {}\ncIsTransient: {}\ncUsesPlacementCube: {}\ncShow: {}\ncHitThreshold: {}\ncAvoidEdges: {}\ncFootprintX: {}\ncFootprintY: {}\ncFootprintZ: {}\ncPlacementFootprintX: {}\ncPlacementFootprintY: {}\ncPlacementFootprintZ: {}\ncAvailableAtStartup: {}\n",
+        Ok(format!("\n\n[Details]\n\nEntity Type Address: {:#x}\nType Name: {}\nCodename: {}\n\n[Configuration]\n\nncolors: {}\ncIconZoom: {}\ncExpansionID: {}\ncMovable: {}\ncWalkable: {}\ncWalkableByTall: {}\ncRubbleable: {}\ncUseNumbersInName: {}\ncUsesRealShadows: {}\ncHasShadowImages: {}\ncForceShadowBlack: {}\ncDrawsLate: {}\ncHeight: {}\ncDepth: {}\ncHasUnderwaterSection: {}\ncIsTransient: {}\ncUsesPlacementCube: {}\ncShow: {}\ncHitThreshold: {}\ncAvoidEdges: {}\ncFootprintX: {}\ncFootprintY: {}\ncFootprintZ: {}\ncPlacementFootprintX: {}\ncPlacementFootprintY: {}\ncPlacementFootprintZ: {}\ncAvailableAtStartup: {}\n\n",
         entity_type_address,
-            entity_type.type_name,
-            entity_type.codename,
-            entity_type.ncolors,
-            entity_type.icon_zoom as u32,
-            entity_type.expansion_id as u32,
-            entity_type.movable as u32,
-            entity_type.walkable as u32,
-            entity_type.walkable_by_tall as u32,
-            entity_type.rubbleable as u32,
-            entity_type.use_numbers_in_name as u32,
-            entity_type.uses_real_shadows as u32,
-            entity_type.has_shadow_images as u32,
-            entity_type.force_shadow_black as u32,
-            entity_type.draws_late as u32,
-            entity_type.height,
-            entity_type.depth,
-            entity_type.has_underwater_section as u32,
-            entity_type.is_transient as u32,
-            entity_type.uses_placement_cube as u32,
-            entity_type.show as u32,
-            entity_type.hit_threshold,
-            entity_type.avoid_edges as u32,
-            entity_type.footprintx,
-            entity_type.footprinty,
-            entity_type.footprintz,
-            entity_type.placement_footprintx,
-            entity_type.placement_footprinty,
-            entity_type.placement_footprintz,
-            entity_type.available_at_startup as u32
-            ))
+        entity_type.get_type_name(),
+        entity_type.get_codename(),
+        entity_type.ncolors,
+        entity_type.icon_zoom as u32,
+        entity_type.expansion_id as u32,
+        entity_type.movable as u32,
+        entity_type.walkable as u32,
+        entity_type.walkable_by_tall as u32,
+        entity_type.rubbleable as u32,
+        entity_type.use_numbers_in_name as u32,
+        entity_type.uses_real_shadows as u32,
+        entity_type.has_shadow_images as u32,
+        entity_type.force_shadow_black as u32,
+        entity_type.draws_late as u32,
+        entity_type.height,
+        entity_type.depth,
+        entity_type.has_underwater_section as u32,
+        entity_type.is_transient as u32,
+        entity_type.uses_placement_cube as u32,
+        entity_type.show as u32,
+        entity_type.hit_threshold,
+        entity_type.avoid_edges as u32,
+        entity_type.footprintx,
+        entity_type.footprinty,
+        entity_type.footprintz,
+        entity_type.placement_footprintx,
+        entity_type.placement_footprinty,
+        entity_type.placement_footprintz,
+        entity_type.available_at_startup as u32       
+        ))
     }
     else if _args.len() == 2 {
         if _args[0] == "-ncolors" { // Note: this is a double pointer, so not recommended to use yet

--- a/src/bfentitytype.rs
+++ b/src/bfentitytype.rs
@@ -100,7 +100,7 @@ impl BFEntityType for EntityType {
     fn set_icon_zoom(&self, icon_zoom: bool) {
         unsafe {
             let icon_zoom_ptr: *mut bool = (self.this + 0x050) as *mut bool;
-            *icon_zoom_ptr = icon_zoom;
+            *(icon_zoom_ptr as *mut bool) = icon_zoom;
         }
     }
 
@@ -122,7 +122,7 @@ impl BFEntityType for EntityType {
     fn set_movable(&self, movable: bool) {
         unsafe {
             let movable_ptr: *mut bool = (self.this + 0x055) as *mut bool;
-            *movable_ptr = movable;
+            *(movable_ptr as *mut bool) = movable;
         }
     }
 
@@ -454,7 +454,7 @@ pub fn command_selected_type(_args: Vec<&str>) -> Result<String, &'static str> {
         ))
     }
     else if _args.len() == 2 {
-        if _args[0] == "-ncolors" {
+        if _args[0] == "-ncolors" { // Note: this is a double pointer, so not recommended to use yet
             entity_type.set_ncolors(_args[1].parse::<u32>().unwrap());
             return Ok(format!("ncolors set to {}", _args[1]));
         }

--- a/src/bfentitytype.rs
+++ b/src/bfentitytype.rs
@@ -4,567 +4,219 @@ use crate::ztui::get_selected_entity_type;
 
 use tracing::info;
 
-trait BFEntityType {
-    fn get_ncolors(&self) -> u32; // 0x038
-    fn set_ncolors(&self, ncolors: u32); // 0x038
-    fn get_icon_zoom(&self) -> bool; // 0x050
-    fn set_icon_zoom(&self, icon_zoom: bool); // 0x050
-    fn get_expansion_id(&self) -> bool; // 0x054
-    fn set_expansion_id(&self, expansion_id: bool); // 0x054
-    fn get_movable(&self) -> bool; // 0x055
-    fn set_movable(&self, movable: bool); // 0x055
-    fn get_walkable(&self) -> bool; // 0x056
-    fn set_walkable(&self, walkable: bool); // 0x056
-    fn get_walkable_by_tall(&self) -> bool; // 0x057
-    fn set_walkable_by_tall(&self, walkable_by_tall: bool); // 0x057
-    fn get_rubbleable(&self) -> bool; // 0x059
-    fn set_rubbleable(&self, rubbleable: bool); // 0x059
-    fn get_use_numbers_in_name(&self) -> bool; // 0x05B
-    fn set_use_numbers_in_name(&self, use_numbers_in_name: bool); // 0x05B
-    fn get_uses_real_shadows(&self) -> bool; // 0x05C
-    fn set_uses_real_shadows(&self, uses_real_shadows: bool); // 0x05C
-    fn get_has_shadow_images(&self) -> bool; // 0x05D
-    fn set_has_shadow_images(&self, has_shadow_images: bool); // 0x05D
-    fn get_force_shadow_black(&self) -> bool; // 0x05E
-    fn set_force_shadow_black(&self, force_shadow_black: bool); // 0x05E
-    fn get_draws_late(&self) -> bool; // 0x060 <---- Might need double checking, not available in viewing canopies
-    fn set_draws_late(&self, draws_late: bool); // 0x060
-    fn get_height(&self) -> u32; // 0x064
-    fn set_height(&self, height: u32); // 0x064
-    fn get_depth(&self) -> u32; // 0x068
-    fn set_depth(&self, depth: u32); // 0x068
-    fn get_has_underwater_section(&self) -> bool; // 0x06C
-    fn set_has_underwater_section(&self, has_underwater_section: bool); // 0x06C
-    fn get_is_transient(&self) -> bool; // 0x06D
-    fn set_is_transient(&self, is_transient: bool); // 0x06D
-    fn get_uses_placement_cube(&self) -> bool; // 0x06E
-    fn set_uses_placement_cube(&self, uses_placement_cube: bool); // 0x06E
-    fn get_show(&self) -> bool; // 0x06F
-    fn set_show(&self, show: bool); // 0x06F
-    fn get_hit_threshold(&self) -> u32; // 0x070
-    fn set_hit_threshold(&self, hit_threshold: u32); // 0x070
-    fn get_avoid_edges(&self) -> bool; // 0x074
-    fn set_avoid_edges(&self, avoid_edges: bool); // 0x074
-    fn get_type_name(&self) -> String; // 0x0A4, 0x0A8
-    fn set_type_name(&self, type_name: String); // 0x0A4, 
-    fn get_codename(&self) -> String; // 0x098, 0x09C
-    fn set_codename(&self, codename: String); // 0x098, 0x09C
-    fn get_footprintx(&self) -> u32; // 0x0B4
-    fn set_footprintx(&self, footprintx: u32); // 0x0B4
-    fn get_footprinty(&self) -> u32; // 0x0B8
-    fn set_footprinty(&self, footprinty: u32); // 0x0B8
-    fn get_footprintz(&self) -> u32; // 0x0BC
-    fn set_footprintz(&self, footprintz: u32); // 0x0BC
-    fn get_placement_footprintx(&self) -> u32; // 0x0C0
-    fn set_placement_footprintx(&self, placement_footprintx: u32); // 0x0C0
-    fn get_placement_footprinty(&self) -> u32; // 0x0C4
-    fn set_placement_footprinty(&self, placement_footprinty: u32); // 0x0C4
-    fn get_placement_footprintz(&self) -> i32; // 0x0C8
-    fn set_placement_footprintz(&self, placement_footprintz: i32); // 0x0C8
-    fn get_available_at_startup(&self) -> bool; // 0x0CC
-    fn set_available_at_startup(&self, available_at_startup: bool); // 0x0CC
-    fn new(ptr: u32) -> Self;
-}
-
 #[derive(Debug)]
 #[repr(C)]
-pub struct EntityType {
-    this: u32,
+struct BFEntityType {
+    pad1: [u8; 0x038], // -- padding: 56 bytes
+    ncolors: u32, // 0x038
+    pad2: [u8; 0x050 - 0x03C], // -- padding: 20 bytes
+    icon_zoom: bool, // 0x050
+    pad3: [u8; 0x054 - 0x051], // -- padding: 3 bytes
+    expansion_id: bool, // 0x054
+    movable: bool, // 0x055
+    walkable: bool, // 0x056
+    walkable_by_tall: bool, // 0x057
+    pad4: [u8; 0x059 - 0x058], // -- padding: 1 byte
+    rubbleable: bool, // 0x059
+    pad5: [u8; 0x05B - 0x05A], // -- padding: 1 byte
+    use_numbers_in_name: bool, // 0x05B
+    uses_real_shadows: bool, // 0x05C
+    has_shadow_images: bool, // 0x05D
+    force_shadow_black: bool, // 0x05E
+    pad6: [u8; 0x060 - 0x05F], // -- padding: 1 byte
+    draws_late: bool, // 0x060
+    pad7: [u8; 0x064 - 0x061], // -- padding: 3 bytes
+    height: u32, // 0x064
+    depth: u32, // 0x068
+    has_underwater_section: bool, // 0x06C
+    is_transient: bool, // 0x06D
+    uses_placement_cube: bool, // 0x06E
+    show: bool, // 0x06F
+    hit_threshold: u32, // 0x070
+    avoid_edges: bool, // 0x074
+    pad8: [u8; 0x098 - 0x075], // -- padding: 27 bytes
+    codename: String, // 0x098
+    pad9: [u8; 0x0A4 - 0x09C], // -- padding: 8 bytes
+    type_name: String, // 0x0A4
+    pad10: [u8; 0x0B0 - 0x0A8], // -- padding: 8 bytes
+    footprintx: u32, // 0x0B4
+    footprinty: u32, // 0x0B8
+    footprintz: u32, // 0x0BC
+    pad11: [u8; 0x0C0 - 0x0BC], // -- padding: 4 bytes
+    placement_footprintx: u32, // 0x0C0
+    placement_footprinty: u32, // 0x0C4
+    placement_footprintz: i32, // 0x0C8
+    pad12: [u8; 0x0CC - 0x0C8], // -- padding: 4 bytes
+    available_at_startup: bool // 0x0CC
 }
 
-impl BFEntityType for EntityType {
-    fn new(ptr: u32) -> EntityType {
-        EntityType {
-            this : get_from_memory::<u32>(ptr),
-        }
+impl BFEntityType {
+    // returns the instance of the ZTGameMgr struct
+    unsafe fn new(ptr: *mut BFEntityType) -> &'static mut BFEntityType {
+        &mut *ptr
     }
-
-    fn get_ncolors(&self) -> u32 {
-        let ncolors_ptr = get_from_memory::<u32>(self.this + 0x038);
-        let ncolors = get_from_memory::<u32>(ncolors_ptr);
-        ncolors
-    }
-
-    // TODO: this should be a double pointer to set, like above
-    fn set_ncolors(&self, ncolors: u32) {
-        unsafe {
-            let ncolors_ptr: *mut u32 = (self.this + 0x038) as *mut u32;
-            *ncolors_ptr = ncolors;
-        }
-    }
-
-    fn get_icon_zoom(&self) -> bool {
-        get_from_memory::<bool>(self.this + 0x050)
-    }
-
-    fn set_icon_zoom(&self, icon_zoom: bool) {
-        unsafe {
-            let icon_zoom_ptr: *mut bool = (self.this + 0x050) as *mut bool;
-            *(icon_zoom_ptr as *mut bool) = icon_zoom;
-        }
-    }
-
-    fn get_expansion_id(&self) -> bool {
-        get_from_memory::<bool>(self.this + 0x054)
-    }
-
-    fn set_expansion_id(&self, expansion_id: bool) {
-        unsafe {
-            let expansion_id_ptr: *mut bool = (self.this + 0x054) as *mut bool;
-            *expansion_id_ptr = expansion_id;
-        }
-    }
-
-    fn get_movable(&self) -> bool {
-        get_from_memory::<bool>(self.this + 0x055)
-    }
-
-    fn set_movable(&self, movable: bool) {
-        unsafe {
-            let movable_ptr: *mut bool = (self.this + 0x055) as *mut bool;
-            *(movable_ptr as *mut bool) = movable;
-        }
-    }
-
-    fn get_walkable(&self) -> bool {
-        get_from_memory::<bool>(self.this + 0x056)
-    }
-
-    fn set_walkable(&self, walkable: bool) {
-        unsafe {
-            let walkable_ptr: *mut bool = (self.this + 0x056) as *mut bool;
-            *walkable_ptr = walkable;
-        }
-    }
-
-    fn get_walkable_by_tall(&self) -> bool {
-        get_from_memory::<bool>(self.this + 0x057)
-    }
-
-    fn set_walkable_by_tall(&self, walkable_by_tall: bool) {
-        unsafe {
-            let walkable_by_tall_ptr: *mut bool = (self.this + 0x057) as *mut bool;
-            *walkable_by_tall_ptr = walkable_by_tall;
-        }
-    }
-
-    fn get_rubbleable(&self) -> bool {
-        get_from_memory::<bool>(self.this + 0x059)
-    }
-
-    fn set_rubbleable(&self, rubbleable: bool) {
-        unsafe {
-            let rubbleable_ptr: *mut bool = (self.this + 0x059) as *mut bool;
-            *rubbleable_ptr = rubbleable;
-        }
-    }
-
-    fn get_use_numbers_in_name(&self) -> bool {
-        get_from_memory::<bool>(self.this + 0x05B)
-    }
-
-    fn set_use_numbers_in_name(&self, use_numbers_in_name: bool) {
-        unsafe {
-            let use_numbers_in_name_ptr: *mut bool = (self.this + 0x05B) as *mut bool;
-            *use_numbers_in_name_ptr = use_numbers_in_name;
-        }
-    }
-
-    fn get_uses_real_shadows(&self) -> bool {
-        get_from_memory::<bool>(self.this + 0x05C)
-    }
-
-    fn set_uses_real_shadows(&self, uses_real_shadows: bool) {
-        unsafe {
-            let uses_real_shadows_ptr: *mut bool = (self.this + 0x05C) as *mut bool;
-            *uses_real_shadows_ptr = uses_real_shadows;
-        }
-    }
-
-    fn get_has_shadow_images(&self) -> bool {
-        get_from_memory::<bool>(self.this + 0x05D)
-    }
-
-    fn set_has_shadow_images(&self, has_shadow_images: bool) {
-        unsafe {
-            let has_shadow_images_ptr: *mut bool = (self.this + 0x05D) as *mut bool;
-            *has_shadow_images_ptr = has_shadow_images;
-        }
-    }
-
-    fn get_force_shadow_black(&self) -> bool {
-        get_from_memory::<bool>(self.this + 0x05E)
-    }
-
-    fn set_force_shadow_black(&self, force_shadow_black: bool) {
-        unsafe {
-            let force_shadow_black_ptr: *mut bool = (self.this + 0x05E) as *mut bool;
-            *force_shadow_black_ptr = force_shadow_black;
-        }
-    }
-
-    fn get_draws_late(&self) -> bool {
-        get_from_memory::<bool>(self.this + 0x060)
-    }
-
-    fn set_draws_late(&self, draws_late: bool) {
-        unsafe {
-            let draws_late_ptr: *mut bool = (self.this + 0x060) as *mut bool;
-            *draws_late_ptr = draws_late;
-        }
-    }
-
-    fn get_height(&self) -> u32 {
-        get_from_memory::<u32>(self.this + 0x064)
-    }
-
-    fn set_height(&self, height: u32) {
-        unsafe {
-            let height_ptr: *mut u32 = (self.this + 0x064) as *mut u32;
-            *height_ptr = height;
-        }
-    }
-
-    fn get_depth(&self) -> u32 {
-        get_from_memory::<u32>(self.this + 0x068)
-    }
-
-    fn set_depth(&self, depth: u32) {
-        unsafe {
-            let depth_ptr: *mut u32 = (self.this + 0x068) as *mut u32;
-            *depth_ptr = depth;
-        }
-    }
-
-    fn get_has_underwater_section(&self) -> bool {
-        get_from_memory::<bool>(self.this + 0x06C)
-    }
-
-    fn set_has_underwater_section(&self, has_underwater_section: bool) {
-        unsafe {
-            let has_underwater_section_ptr: *mut bool = (self.this + 0x06C) as *mut bool;
-            *has_underwater_section_ptr = has_underwater_section;
-        }
-    }
-
-    fn get_is_transient(&self) -> bool {
-        get_from_memory::<bool>(self.this + 0x06D)
-    }
-
-    fn set_is_transient(&self, is_transient: bool) {
-        unsafe {
-            let is_transient_ptr: *mut bool = (self.this + 0x06D) as *mut bool;
-            *is_transient_ptr = is_transient;
-        }
-    }
-
-    fn get_uses_placement_cube(&self) -> bool {
-        get_from_memory::<bool>(self.this + 0x06E)
-    }
-
-    fn set_uses_placement_cube(&self, uses_placement_cube: bool) {
-        unsafe {
-            let uses_placement_cube_ptr: *mut bool = (self.this + 0x06E) as *mut bool;
-            *uses_placement_cube_ptr = uses_placement_cube;
-        }
-    }
-
-    fn get_show(&self) -> bool {
-        get_from_memory::<bool>(self.this + 0x06F)
-    }
-
-    fn set_show(&self, show: bool) {
-        unsafe {
-            let show_ptr: *mut bool = (self.this + 0x06F) as *mut bool;
-            *show_ptr = show;
-        }
-    }
-
-    fn get_hit_threshold(&self) -> u32 {
-        get_from_memory::<u32>(self.this + 0x070)
-    }
-
-    fn set_hit_threshold(&self, hit_threshold: u32) {
-        unsafe {
-            let hit_threshold_ptr: *mut u32 = (self.this + 0x070) as *mut u32;
-            *hit_threshold_ptr = hit_threshold;
-        }
-    }
-
-    fn get_avoid_edges(&self) -> bool {
-        get_from_memory::<bool>(self.this + 0x074)
-    }
-
-    fn set_avoid_edges(&self, avoid_edges: bool) {
-        unsafe {
-            let avoid_edges_ptr: *mut bool = (self.this + 0x074) as *mut bool;
-            *avoid_edges_ptr = avoid_edges;
-        }
-    }
-
-    fn get_type_name(&self) -> String {
-        let type_name_ptr = get_from_memory::<u32>(self.this + 0x0A4);
-        get_string_from_memory(type_name_ptr)
-    }
-
-    fn set_type_name(&self, type_name: String) {
-        unsafe {
-            let type_name_ptr: *mut String = (self.this + 0x0A4) as *mut String;
-            *type_name_ptr = type_name;
-        }
-    }
-
-    fn get_codename(&self) -> String {
-        let codename_ptr = get_from_memory::<u32>(self.this + 0x098);
-        get_string_from_memory(codename_ptr)
-    }
-
-    fn set_codename(&self, codename: String) {
-        unsafe {
-            let codename_ptr: *mut String = (self.this + 0x098) as *mut String;
-            *codename_ptr = codename;
-        }
-    }
-
-    fn get_footprintx(&self) -> u32 {
-        get_from_memory::<u32>(self.this + 0x0B4)
-    }
-
-    fn set_footprintx(&self, footprintx: u32) {
-        unsafe {
-            let footprintx_ptr: *mut u32 = (self.this + 0x0B4) as *mut u32;
-            *footprintx_ptr = footprintx;
-        }
-    }
-
-    fn get_footprinty(&self) -> u32 {
-        get_from_memory::<u32>(self.this + 0x0B8)
-    }
-
-    fn set_footprinty(&self, footprinty: u32) {
-        unsafe {
-            let footprinty_ptr: *mut u32 = (self.this + 0x0B8) as *mut u32;
-            *footprinty_ptr = footprinty;
-        }
-    }
-
-    fn get_footprintz(&self) -> u32 {
-        get_from_memory::<u32>(self.this + 0x0BC)
-    }
-
-    fn set_footprintz(&self, footprintz: u32) {
-        unsafe {
-            let footprintz_ptr: *mut u32 = (self.this + 0x0BC) as *mut u32;
-            *footprintz_ptr = footprintz;
-        }
-    }
-
-    fn get_placement_footprintx(&self) -> u32 {
-        get_from_memory::<u32>(self.this + 0x0C0)
-    }
-
-    fn set_placement_footprintx(&self, placement_footprintx: u32) {
-        unsafe {
-            let placement_footprintx_ptr: *mut u32 = (self.this + 0x0C0) as *mut u32;
-            *placement_footprintx_ptr = placement_footprintx;
-        }
-    }
-
-    fn get_placement_footprinty(&self) -> u32 {
-        get_from_memory::<u32>(self.this + 0x0C4)
-    }
-
-    fn set_placement_footprinty(&self, placement_footprinty: u32) {
-        unsafe {
-            let placement_footprinty_ptr: *mut u32 = (self.this + 0x0C4) as *mut u32;
-            *placement_footprinty_ptr = placement_footprinty;
-        }
-    }
-
-    fn get_placement_footprintz(&self) -> i32 {
-        get_from_memory::<i32>(self.this + 0x0C8)
-    }
-
-    fn set_placement_footprintz(&self, placement_footprintz: i32) {
-        unsafe {
-            let placement_footprintz_ptr: *mut i32 = (self.this + 0x0C8) as *mut i32;
-            *placement_footprintz_ptr = placement_footprintz;
-        }
-    }
-
-    fn get_available_at_startup(&self) -> bool {
-        get_from_memory::<bool>(self.this + 0x0CC)
-    }
-
-    fn set_available_at_startup(&self, available_at_startup: bool) {
-        unsafe {
-            let available_at_startup_ptr: *mut bool = (self.this + 0x0CC) as *mut bool;
-            *available_at_startup_ptr = available_at_startup;
-        }
-    }
-
 }
-
 pub fn command_selected_type(_args: Vec<&str>) -> Result<String, &'static str> {
     
     let entity_type_address = get_selected_entity_type();
-    let entity_type_ptr = get_from_memory::<u32>(entity_type_address);
-    if entity_type_ptr == 0 {
+    let entity_type_ptr = get_from_memory::<*mut BFEntityType>(entity_type_address);
+    if entity_type_ptr == std::ptr::null_mut() {
         return Err("No entity selected");
     }
-    let entity_type = EntityType::new(entity_type_address);
+    let entity_type = unsafe {BFEntityType::new(entity_type_ptr)};
     if _args.len() == 0 {
-        return Ok(format!("Entity type at address {:#x}", entity_type_ptr));
+        return Ok(format!("Entity type at address {:#x}", entity_type_address));
     }
     if _args[0] == "-v" {
 
-        info!("Printing configuration for entity type at address {:#x}", entity_type_ptr);
+        info!("Printing configuration for entity type at address {:#x}", entity_type_address);
     
         Ok(format!("\n\n[Details]\nEntityType: {:#x}\nType Name: {}\nCodename: {}\n\n[Printed configuration]\nncolors: {}\ncIconZoom: {}\ncExpansionID: {}\ncMovable: {}\ncWalkable: {}\ncWalkableByTall: {}\ncRubbleable: {}\ncUseNumbersInName: {}\ncUsesRealShadows: {}\ncHasShadowImages: {}\ncForceShadowBlack: {}\ncDrawsLate: {}\ncHeight: {}\ncDepth: {}\ncHasUnderwaterSection: {}\ncIsTransient: {}\ncUsesPlacementCube: {}\ncShow: {}\ncHitThreshold: {}\ncAvoidEdges: {}\ncFootprintX: {}\ncFootprintY: {}\ncFootprintZ: {}\ncPlacementFootprintX: {}\ncPlacementFootprintY: {}\ncPlacementFootprintZ: {}\ncAvailableAtStartup: {}\n",
-            entity_type.this,
-            entity_type.get_type_name(),
-            entity_type.get_codename(),
-            entity_type.get_ncolors(),
-            entity_type.get_icon_zoom() as u32,
-            entity_type.get_expansion_id() as u32,
-            entity_type.get_movable() as u32,
-            entity_type.get_walkable() as u32,
-            entity_type.get_walkable_by_tall() as u32,
-            entity_type.get_rubbleable() as u32,
-            entity_type.get_use_numbers_in_name() as u32,
-            entity_type.get_uses_real_shadows() as u32,
-            entity_type.get_has_shadow_images() as u32,
-            entity_type.get_force_shadow_black() as u32,
-            entity_type.get_draws_late() as u32,
-            entity_type.get_height(),
-            entity_type.get_depth(),
-            entity_type.get_has_underwater_section() as u32,
-            entity_type.get_is_transient() as u32,
-            entity_type.get_uses_placement_cube() as u32,
-            entity_type.get_show() as u32,
-            entity_type.get_hit_threshold(),
-            entity_type.get_avoid_edges() as u32,
-            entity_type.get_footprintx(),
-            entity_type.get_footprinty(),
-            entity_type.get_footprintz(),
-            entity_type.get_placement_footprintx(),
-            entity_type.get_placement_footprinty(),
-            entity_type.get_placement_footprintz(),
-            entity_type.get_available_at_startup() as u32
-        ))
+        entity_type_address,
+            entity_type.type_name,
+            entity_type.codename,
+            entity_type.ncolors,
+            entity_type.icon_zoom as u32,
+            entity_type.expansion_id as u32,
+            entity_type.movable as u32,
+            entity_type.walkable as u32,
+            entity_type.walkable_by_tall as u32,
+            entity_type.rubbleable as u32,
+            entity_type.use_numbers_in_name as u32,
+            entity_type.uses_real_shadows as u32,
+            entity_type.has_shadow_images as u32,
+            entity_type.force_shadow_black as u32,
+            entity_type.draws_late as u32,
+            entity_type.height,
+            entity_type.depth,
+            entity_type.has_underwater_section as u32,
+            entity_type.is_transient as u32,
+            entity_type.uses_placement_cube as u32,
+            entity_type.show as u32,
+            entity_type.hit_threshold,
+            entity_type.avoid_edges as u32,
+            entity_type.footprintx,
+            entity_type.footprinty,
+            entity_type.footprintz,
+            entity_type.placement_footprintx,
+            entity_type.placement_footprinty,
+            entity_type.placement_footprintz,
+            entity_type.available_at_startup as u32
+            ))
     }
     else if _args.len() == 2 {
         if _args[0] == "-ncolors" { // Note: this is a double pointer, so not recommended to use yet
-            entity_type.set_ncolors(_args[1].parse::<u32>().unwrap());
+            entity_type.ncolors = _args[1].parse::<u32>().unwrap();
             return Ok(format!("ncolors set to {}", _args[1]));
         }
         else if _args[0] == "-cIconZoom" {
-            entity_type.set_icon_zoom(_args[1].parse::<bool>().unwrap());
+            entity_type.icon_zoom = _args[1].parse::<bool>().unwrap();
             return Ok(format!("cIconZoom set to {}", _args[1]));
         }
         else if _args[0] == "-cExpansionID" {
-            entity_type.set_expansion_id(_args[1].parse::<bool>().unwrap());
+            entity_type.expansion_id = _args[1].parse::<bool>().unwrap();
             return Ok(format!("cExpansionID set to {}", _args[1]));
         }
         else if _args[0] == "-cMovable" {
-            entity_type.set_movable(_args[1].parse::<bool>().unwrap());
+            entity_type.movable = _args[1].parse::<bool>().unwrap();
             return Ok(format!("cMovable set to {}", _args[1]));
         }
         else if _args[0] == "-cWalkable" {
-            entity_type.set_walkable(_args[1].parse::<bool>().unwrap());
+            entity_type.walkable = _args[1].parse::<bool>().unwrap();
             return Ok(format!("cWalkable set to {}", _args[1]));
         }
         else if _args[0] == "-cWalkableByTall" {
-            entity_type.set_walkable_by_tall(_args[1].parse::<bool>().unwrap());
+            entity_type.walkable_by_tall = _args[1].parse::<bool>().unwrap();
             return Ok(format!("cWalkableByTall set to {}", _args[1]));
         }
         else if _args[0] == "-cRubbleable" {
-            entity_type.set_rubbleable(_args[1].parse::<bool>().unwrap());
+            entity_type.rubbleable = _args[1].parse::<bool>().unwrap();
             return Ok(format!("cRubbleable set to {}", _args[1]));
         }
         else if _args[0] == "-cUseNumbersInName" {
-            entity_type.set_use_numbers_in_name(_args[1].parse::<bool>().unwrap());
+            entity_type.use_numbers_in_name = _args[1].parse::<bool>().unwrap();
             return Ok(format!("cUseNumbersInName set to {}", _args[1]));
         }
         else if _args[0] == "-cUsesRealShadows" {
-            entity_type.set_uses_real_shadows(_args[1].parse::<bool>().unwrap());
+            entity_type.uses_real_shadows = _args[1].parse::<bool>().unwrap();
             return Ok(format!("cUsesRealShadows set to {}", _args[1]));
         }
         else if _args[0] == "-cHasShadowImages" {
-            entity_type.set_has_shadow_images(_args[1].parse::<bool>().unwrap());
+            entity_type.has_shadow_images = _args[1].parse::<bool>().unwrap();
             return Ok(format!("cHasShadowImages set to {}", _args[1]));
         }
         else if _args[0] == "-cForceShadowBlack" {
-            entity_type.set_force_shadow_black(_args[1].parse::<bool>().unwrap());
+            entity_type.force_shadow_black = _args[1].parse::<bool>().unwrap();
             return Ok(format!("cForceShadowBlack set to {}", _args[1]));
         }
         else if _args[0] == "-cDrawsLate" {
-            entity_type.set_draws_late(_args[1].parse::<bool>().unwrap());
+            entity_type.draws_late = _args[1].parse::<bool>().unwrap();
             return Ok(format!("cDrawsLate set to {}", _args[1]));
         }
         else if _args[0] == "-cHeight" {
-            entity_type.set_height(_args[1].parse::<u32>().unwrap());
+            entity_type.height = _args[1].parse::<u32>().unwrap();
             return Ok(format!("cHeight set to {}", _args[1]));
         }
         else if _args[0] == "-cDepth" {
-            entity_type.set_depth(_args[1].parse::<u32>().unwrap());
+            entity_type.depth = _args[1].parse::<u32>().unwrap();
             return Ok(format!("cDepth set to {}", _args[1]));
         }
         else if _args[0] == "-cHasUnderwaterSection" {
-            entity_type.set_has_underwater_section(_args[1].parse::<bool>().unwrap());
+            entity_type.has_underwater_section = _args[1].parse::<bool>().unwrap();
             return Ok(format!("cHasUnderwaterSection set to {}", _args[1]));
         }
         else if _args[0] == "-cIsTransient" {
-            entity_type.set_is_transient(_args[1].parse::<bool>().unwrap());
+            entity_type.is_transient = _args[1].parse::<bool>().unwrap();
             return Ok(format!("cIsTransient set to {}", _args[1]));
         }
         else if _args[0] == "-cUsesPlacementCube" {
-            entity_type.set_uses_placement_cube(_args[1].parse::<bool>().unwrap());
+            entity_type.uses_placement_cube = _args[1].parse::<bool>().unwrap();
             return Ok(format!("cUsesPlacementCube set to {}", _args[1]));
         }
         else if _args[0] == "-cShow" {
-            entity_type.set_show(_args[1].parse::<bool>().unwrap());
+            entity_type.show = _args[1].parse::<bool>().unwrap();
             return Ok(format!("cShow set to {}", _args[1]));
         }
         else if _args[0] == "-cHitThreshold" {
-            entity_type.set_hit_threshold(_args[1].parse::<u32>().unwrap());
+            entity_type.hit_threshold = _args[1].parse::<u32>().unwrap();
             return Ok(format!("cHitThreshold set to {}", _args[1]));
         }
         else if _args[0] == "-cAvoidEdges" {
-            entity_type.set_avoid_edges(_args[1].parse::<bool>().unwrap());
+            entity_type.avoid_edges = _args[1].parse::<bool>().unwrap();
             return Ok(format!("cAvoidEdges set to {}", _args[1]));
         }
         else if _args[0] == "-cFootprintX" {
-            entity_type.set_footprintx(_args[1].parse::<u32>().unwrap());
+            entity_type.footprintx = _args[1].parse::<u32>().unwrap();
             return Ok(format!("cFootprintX set to {}", _args[1]));
         }
         else if _args[0] == "-cFootprintY" {
-            entity_type.set_footprinty(_args[1].parse::<u32>().unwrap());
+            entity_type.footprinty = _args[1].parse::<u32>().unwrap();
             return Ok(format!("cFootprintY set to {}", _args[1]));
         }
         else if _args[0] == "-cFootprintZ" {
-            entity_type.set_footprintz(_args[1].parse::<u32>().unwrap());
+            entity_type.footprintz = _args[1].parse::<u32>().unwrap();
             return Ok(format!("cFootprintZ set to {}", _args[1]));
         }
         else if _args[0] == "-cPlacementFootprintX" {
-            entity_type.set_placement_footprintx(_args[1].parse::<u32>().unwrap());
+            entity_type.placement_footprintx = _args[1].parse::<u32>().unwrap();
             return Ok(format!("cPlacementFootprintX set to {}", _args[1]));
         }
         else if _args[0] == "-cPlacementFootprintY" {
-            entity_type.set_placement_footprinty(_args[1].parse::<u32>().unwrap());
+            entity_type.placement_footprinty = _args[1].parse::<u32>().unwrap();
             return Ok(format!("cPlacementFootprintY set to {}", _args[1]));
         }
         else if _args[0] == "-cPlacementFootprintZ" {
-            entity_type.set_placement_footprintz(_args[1].parse::<i32>().unwrap());
+            entity_type.placement_footprintz = _args[1].parse::<i32>().unwrap();
             return Ok(format!("cPlacementFootprintZ set to {}", _args[1]));
         }
         else if _args[0] == "-cAvailableAtStartup" {
-            entity_type.set_available_at_startup(_args[1].parse::<bool>().unwrap());
+            entity_type.available_at_startup = _args[1].parse::<bool>().unwrap();
             return Ok(format!("cAvailableAtStartup set to {}", _args[1]));
         }
         else {
             return Ok("Invalid argument".to_string());
         }
+        
     }
     else {
         Ok("Invalid argument".to_string())

--- a/src/bfentitytype.rs
+++ b/src/bfentitytype.rs
@@ -1,70 +1,69 @@
-use crate::debug_dll::{get_from_memory, get_string_from_memory};
 use crate::add_to_command_register;
+use crate::debug_dll::{get_from_memory, get_string_from_memory};
+use crate::ztui::get_selected_entity_type;
 
 use tracing::info;
-use std::collections::HashMap;
-use std::fmt;
-use num_enum::FromPrimitive;
 
 trait BFEntityType {
-    fn get_ncolors() -> u32; // 0x038
-    fn set_ncolors(ncolors: u32); // 0x038
-    fn get_icon_zoom() -> bool; // 0x050
-    fn set_icon_zoom(icon_zoom: bool); // 0x050
-    fn get_expansion_id() -> bool; // 0x054
-    fn set_expansion_id(expansion_id: bool); // 0x054
-    fn get_movable() -> bool; // 0x055
-    fn set_movable(movable: bool); // 0x055
-    fn get_walkable() -> bool; // 0x056
-    fn set_walkable(walkable: bool); // 0x056
-    fn get_walkable_by_tall() -> bool; // 0x057
-    fn set_walkable_by_tall(walkable_by_tall: bool); // 0x057
-    fn get_rubbleable() -> bool; // 0x059
-    fn set_rubbleable(rubbleable: bool); // 0x059
-    fn get_use_numbers_in_name() -> bool; // 0x05B
-    fn set_use_numbers_in_name(use_numbers_in_name: bool); // 0x05B
-    fn get_uses_real_shadows() -> bool; // 0x05C
-    fn set_uses_real_shadows(uses_real_shadows: bool); // 0x05C
-    fn get_has_shadow_images() -> bool; // 0x05D
-    fn set_has_shadow_images(has_shadow_images: bool); // 0x05D
-    fn get_force_shadow_black() -> bool; // 0x05E
-    fn set_force_shadow_black(force_shadow_black: bool); // 0x05E
-    fn get_draws_late() -> bool; // 0x060 <---- Might need double checking, not available in viewing canopies
-    fn set_draws_late(draws_late: bool); // 0x060
-    fn get_height() -> u32; // 0x064
-    fn set_height(height: u32); // 0x064
-    fn get_depth() -> u32; // 0x068
-    fn set_depth(depth: u32); // 0x068
-    fn get_has_underwater_section() -> bool; // 0x06C
-    fn set_has_underwater_section(has_underwater_section: bool); // 0x06C
-    fn get_is_transient() -> bool; // 0x06D
-    fn set_is_transient(is_transient: bool); // 0x06D
-    fn get_uses_placement_cube() -> bool; // 0x06E
-    fn set_uses_placement_cube(uses_placement_cube: bool); // 0x06E
-    fn get_show() -> bool; // 0x06F
-    fn set_show(show: bool); // 0x06F
-    fn get_hit_threshold() -> u32; // 0x070
-    fn set_hit_threshold(hit_threshold: u32); // 0x070
-    fn get_avoid_edges() -> bool; // 0x074
-    fn set_avoid_edges(avoid_edges: bool); // 0x074
-    fn get_type_name() -> String; // 0x0A4, 0x0A8
-    fn set_type_name(type_name: String); // 0x0A4, 
-    fn get_codename() -> String; // 0x098, 0x09C
-    fn set_codename(codename: String); // 0x098, 0x09C
-    fn get_footprintx() -> u32; // 0x0B4
-    fn set_footprintx(footprintx: u32); // 0x0B4
-    fn get_footprinty() -> u32; // 0x0B8
-    fn set_footprinty(footprinty: u32); // 0x0B8
-    fn get_footprintz() -> u32; // 0x0BC
-    fn set_footprintz(footprintz: u32); // 0x0BC
-    fn get_placement_footprintx() -> u32; // 0x0C0
-    fn set_placement_footprintx(placement_footprintx: u32); // 0x0C0
-    fn get_placement_footprinty() -> u32; // 0x0C4
-    fn set_placement_footprinty(placement_footprinty: u32); // 0x0C4
-    fn get_placement_footprintz() -> u32; // 0x0C8
-    fn set_placement_footprintz(placement_footprintz: u32); // 0x0C8
-    fn get_available_at_startup() -> bool; // 0x0CC
-    fn set_available_at_startup(available_at_startup: bool); // 0x0CC
+    fn get_ncolors(&self) -> u32; // 0x038
+    fn set_ncolors(&self, ncolors: u32); // 0x038
+    fn get_icon_zoom(&self) -> bool; // 0x050
+    fn set_icon_zoom(&self, icon_zoom: bool); // 0x050
+    fn get_expansion_id(&self) -> bool; // 0x054
+    fn set_expansion_id(&self, expansion_id: bool); // 0x054
+    fn get_movable(&self) -> bool; // 0x055
+    fn set_movable(&self, movable: bool); // 0x055
+    fn get_walkable(&self) -> bool; // 0x056
+    fn set_walkable(&self, walkable: bool); // 0x056
+    fn get_walkable_by_tall(&self) -> bool; // 0x057
+    fn set_walkable_by_tall(&self, walkable_by_tall: bool); // 0x057
+    fn get_rubbleable(&self) -> bool; // 0x059
+    fn set_rubbleable(&self, rubbleable: bool); // 0x059
+    fn get_use_numbers_in_name(&self) -> bool; // 0x05B
+    fn set_use_numbers_in_name(&self, use_numbers_in_name: bool); // 0x05B
+    fn get_uses_real_shadows(&self) -> bool; // 0x05C
+    fn set_uses_real_shadows(&self, uses_real_shadows: bool); // 0x05C
+    fn get_has_shadow_images(&self) -> bool; // 0x05D
+    fn set_has_shadow_images(&self, has_shadow_images: bool); // 0x05D
+    fn get_force_shadow_black(&self) -> bool; // 0x05E
+    fn set_force_shadow_black(&self, force_shadow_black: bool); // 0x05E
+    fn get_draws_late(&self) -> bool; // 0x060 <---- Might need double checking, not available in viewing canopies
+    fn set_draws_late(&self, draws_late: bool); // 0x060
+    fn get_height(&self) -> u32; // 0x064
+    fn set_height(&self, height: u32); // 0x064
+    fn get_depth(&self) -> u32; // 0x068
+    fn set_depth(&self, depth: u32); // 0x068
+    fn get_has_underwater_section(&self) -> bool; // 0x06C
+    fn set_has_underwater_section(&self, has_underwater_section: bool); // 0x06C
+    fn get_is_transient(&self) -> bool; // 0x06D
+    fn set_is_transient(&self, is_transient: bool); // 0x06D
+    fn get_uses_placement_cube(&self) -> bool; // 0x06E
+    fn set_uses_placement_cube(&self, uses_placement_cube: bool); // 0x06E
+    fn get_show(&self) -> bool; // 0x06F
+    fn set_show(&self, show: bool); // 0x06F
+    fn get_hit_threshold(&self) -> u32; // 0x070
+    fn set_hit_threshold(&self, hit_threshold: u32); // 0x070
+    fn get_avoid_edges(&self) -> bool; // 0x074
+    fn set_avoid_edges(&self, avoid_edges: bool); // 0x074
+    fn get_type_name(&self) -> String; // 0x0A4, 0x0A8
+    fn set_type_name(&self, type_name: String); // 0x0A4, 
+    fn get_codename(&self) -> String; // 0x098, 0x09C
+    fn set_codename(&self, codename: String); // 0x098, 0x09C
+    fn get_footprintx(&self) -> u32; // 0x0B4
+    fn set_footprintx(&self, footprintx: u32); // 0x0B4
+    fn get_footprinty(&self) -> u32; // 0x0B8
+    fn set_footprinty(&self, footprinty: u32); // 0x0B8
+    fn get_footprintz(&self) -> u32; // 0x0BC
+    fn set_footprintz(&self, footprintz: u32); // 0x0BC
+    fn get_placement_footprintx(&self) -> u32; // 0x0C0
+    fn set_placement_footprintx(&self, placement_footprintx: u32); // 0x0C0
+    fn get_placement_footprinty(&self) -> u32; // 0x0C4
+    fn set_placement_footprinty(&self, placement_footprinty: u32); // 0x0C4
+    fn get_placement_footprintz(&self) -> i32; // 0x0C8
+    fn set_placement_footprintz(&self, placement_footprintz: i32); // 0x0C8
+    fn get_available_at_startup(&self) -> bool; // 0x0CC
+    fn set_available_at_startup(&self, available_at_startup: bool); // 0x0CC
+    fn new(ptr: u32) -> Self;
 }
 
 #[derive(Debug)]
@@ -74,241 +73,382 @@ pub struct EntityType {
 }
 
 impl BFEntityType for EntityType {
-    fn this(ptr : u32) -> u32 {
+    fn new(ptr: u32) -> EntityType {
         EntityType {
-            this: ptr
+            this : get_from_memory::<u32>(ptr),
         }
     }
 
-    fn get_ncolors() -> u32 {
-        get_from_memory::<u32>(this + 0x038)
+    fn get_ncolors(&self) -> u32 {
+        let ncolors_ptr = get_from_memory::<u32>(self.this + 0x038);
+        let ncolors = get_from_memory::<u32>(ncolors_ptr);
+        ncolors
     }
 
-    fn set_ncolors(ncolors: u32) {
-        get_from_memory::<u32>(this + 0x038) = ncolors;
+    // TODO: this should be a double pointer to set, like above
+    fn set_ncolors(&self, ncolors: u32) {
+        unsafe {
+            let ncolors_ptr: *mut u32 = (self.this + 0x038) as *mut u32;
+            *ncolors_ptr = ncolors;
+        }
     }
 
-    fn get_icon_zoom() -> bool {
-        get_from_memory::<bool>(this + 0x050)
+    fn get_icon_zoom(&self) -> bool {
+        get_from_memory::<bool>(self.this + 0x050)
     }
 
-    fn set_icon_zoom(icon_zoom: bool) {
-        get_from_memory::<bool>(this + 0x050) = icon_zoom;
+    fn set_icon_zoom(&self, icon_zoom: bool) {
+        unsafe {
+            let icon_zoom_ptr: *mut bool = (self.this + 0x050) as *mut bool;
+            *icon_zoom_ptr = icon_zoom;
+        }
     }
 
-    fn get_expansion_id() -> bool {
-        get_from_memory::<bool>(this + 0x054)
+    fn get_expansion_id(&self) -> bool {
+        get_from_memory::<bool>(self.this + 0x054)
     }
 
-    fn set_expansion_id(expansion_id: bool) {
-        get_from_memory::<bool>(this + 0x054) = expansion_id;
+    fn set_expansion_id(&self, expansion_id: bool) {
+        unsafe {
+            let expansion_id_ptr: *mut bool = (self.this + 0x054) as *mut bool;
+            *expansion_id_ptr = expansion_id;
+        }
     }
 
-    fn get_movable() -> bool {
-        get_from_memory::<bool>(this + 0x055)
+    fn get_movable(&self) -> bool {
+        get_from_memory::<bool>(self.this + 0x055)
     }
 
-    fn set_movable(movable: bool) {
-        get_from_memory::<bool>(this + 0x055) = movable;
+    fn set_movable(&self, movable: bool) {
+        unsafe {
+            let movable_ptr: *mut bool = (self.this + 0x055) as *mut bool;
+            *movable_ptr = movable;
+        }
     }
 
-    fn get_walkable() -> bool {
-        get_from_memory::<bool>(this + 0x056)
+    fn get_walkable(&self) -> bool {
+        get_from_memory::<bool>(self.this + 0x056)
     }
 
-    fn set_walkable(walkable: bool) {
-        get_from_memory::<bool>(this + 0x056) = walkable;
+    fn set_walkable(&self, walkable: bool) {
+        unsafe {
+            let walkable_ptr: *mut bool = (self.this + 0x056) as *mut bool;
+            *walkable_ptr = walkable;
+        }
     }
 
-    fn get_walkable_by_tall() -> bool {
-        get_from_memory::<bool>(this + 0x057)
+    fn get_walkable_by_tall(&self) -> bool {
+        get_from_memory::<bool>(self.this + 0x057)
     }
 
-    fn set_walkable_by_tall(walkable_by_tall: bool) {
-        get_from_memory::<bool>(this + 0x057) = walkable_by_tall;
+    fn set_walkable_by_tall(&self, walkable_by_tall: bool) {
+        unsafe {
+            let walkable_by_tall_ptr: *mut bool = (self.this + 0x057) as *mut bool;
+            *walkable_by_tall_ptr = walkable_by_tall;
+        }
     }
 
-    fn get_rubbleable() -> bool {
-        get_from_memory::<bool>(this + 0x059)
+    fn get_rubbleable(&self) -> bool {
+        get_from_memory::<bool>(self.this + 0x059)
     }
 
-    fn set_rubbleable(rubbleable: bool) {
-        get_from_memory::<bool>(this + 0x059) = rubbleable;
+    fn set_rubbleable(&self, rubbleable: bool) {
+        unsafe {
+            let rubbleable_ptr: *mut bool = (self.this + 0x059) as *mut bool;
+            *rubbleable_ptr = rubbleable;
+        }
     }
 
-    fn get_use_numbers_in_name() -> bool {
-        get_from_memory::<bool>(this + 0x05B)
+    fn get_use_numbers_in_name(&self) -> bool {
+        get_from_memory::<bool>(self.this + 0x05B)
     }
 
-    fn set_use_numbers_in_name(use_numbers_in_name: bool) {
-        get_from_memory::<bool>(this + 0x05B) = use_numbers_in_name;
+    fn set_use_numbers_in_name(&self, use_numbers_in_name: bool) {
+        unsafe {
+            let use_numbers_in_name_ptr: *mut bool = (self.this + 0x05B) as *mut bool;
+            *use_numbers_in_name_ptr = use_numbers_in_name;
+        }
     }
 
-    fn get_uses_real_shadows() -> bool {
-        get_from_memory::<bool>(this + 0x05C)
+    fn get_uses_real_shadows(&self) -> bool {
+        get_from_memory::<bool>(self.this + 0x05C)
     }
 
-    fn set_uses_real_shadows(uses_real_shadows: bool) {
-        get_from_memory::<bool>(this + 0x05C) = uses_real_shadows;
+    fn set_uses_real_shadows(&self, uses_real_shadows: bool) {
+        unsafe {
+            let uses_real_shadows_ptr: *mut bool = (self.this + 0x05C) as *mut bool;
+            *uses_real_shadows_ptr = uses_real_shadows;
+        }
     }
 
-    fn get_has_shadow_images() -> bool {
-        get_from_memory::<bool>(this + 0x05D)
+    fn get_has_shadow_images(&self) -> bool {
+        get_from_memory::<bool>(self.this + 0x05D)
     }
 
-    fn set_has_shadow_images(has_shadow_images: bool) {
-        get_from_memory::<bool>(this + 0x05D) = has_shadow_images;
+    fn set_has_shadow_images(&self, has_shadow_images: bool) {
+        unsafe {
+            let has_shadow_images_ptr: *mut bool = (self.this + 0x05D) as *mut bool;
+            *has_shadow_images_ptr = has_shadow_images;
+        }
     }
 
-    fn get_force_shadow_black() -> bool {
-        get_from_memory::<bool>(this + 0x05E)
+    fn get_force_shadow_black(&self) -> bool {
+        get_from_memory::<bool>(self.this + 0x05E)
     }
 
-    fn set_force_shadow_black(force_shadow_black: bool) {
-        get_from_memory::<bool>(this + 0x05E) = force_shadow_black;
+    fn set_force_shadow_black(&self, force_shadow_black: bool) {
+        unsafe {
+            let force_shadow_black_ptr: *mut bool = (self.this + 0x05E) as *mut bool;
+            *force_shadow_black_ptr = force_shadow_black;
+        }
     }
 
-    fn get_draws_late() -> bool {
-        get_from_memory::<bool>(this + 0x060)
+    fn get_draws_late(&self) -> bool {
+        get_from_memory::<bool>(self.this + 0x060)
     }
 
-    fn set_draws_late(draws_late: bool) {
-        get_from_memory::<bool>(this + 0x060) = draws_late;
+    fn set_draws_late(&self, draws_late: bool) {
+        unsafe {
+            let draws_late_ptr: *mut bool = (self.this + 0x060) as *mut bool;
+            *draws_late_ptr = draws_late;
+        }
     }
 
-    fn get_height() -> u32 {
-        get_from_memory::<u32>(this + 0x064)
+    fn get_height(&self) -> u32 {
+        get_from_memory::<u32>(self.this + 0x064)
     }
 
-    fn set_height(height: u32) {
-        get_from_memory::<u32>(this + 0x064) = height;
+    fn set_height(&self, height: u32) {
+        unsafe {
+            let height_ptr: *mut u32 = (self.this + 0x064) as *mut u32;
+            *height_ptr = height;
+        }
     }
 
-    fn get_depth() -> u32 {
-        get_from_memory::<u32>(this + 0x068)
+    fn get_depth(&self) -> u32 {
+        get_from_memory::<u32>(self.this + 0x068)
     }
 
-    fn set_depth(depth: u32) {
-        get_from_memory::<u32>(this + 0x068) = depth;
+    fn set_depth(&self, depth: u32) {
+        unsafe {
+            let depth_ptr: *mut u32 = (self.this + 0x068) as *mut u32;
+            *depth_ptr = depth;
+        }
     }
 
-    fn get_has_underwater_section() -> bool {
-        get_from_memory::<bool>(this + 0x06C)
+    fn get_has_underwater_section(&self) -> bool {
+        get_from_memory::<bool>(self.this + 0x06C)
     }
 
-    fn set_has_underwater_section(has_underwater_section: bool) {
-        get_from_memory::<bool>(this + 0x06C) = has_underwater_section;
+    fn set_has_underwater_section(&self, has_underwater_section: bool) {
+        unsafe {
+            let has_underwater_section_ptr: *mut bool = (self.this + 0x06C) as *mut bool;
+            *has_underwater_section_ptr = has_underwater_section;
+        }
     }
 
-    fn get_is_transient() -> bool {
-        get_from_memory::<bool>(this + 0x06D)
+    fn get_is_transient(&self) -> bool {
+        get_from_memory::<bool>(self.this + 0x06D)
     }
 
-    fn set_is_transient(is_transient: bool) {
-        get_from_memory::<bool>(this + 0x06D) = is_transient;
+    fn set_is_transient(&self, is_transient: bool) {
+        unsafe {
+            let is_transient_ptr: *mut bool = (self.this + 0x06D) as *mut bool;
+            *is_transient_ptr = is_transient;
+        }
     }
 
-    fn get_uses_placement_cube() -> bool {
-        get_from_memory::<bool>(this + 0x06E)
+    fn get_uses_placement_cube(&self) -> bool {
+        get_from_memory::<bool>(self.this + 0x06E)
     }
 
-    fn set_uses_placement_cube(uses_placement_cube: bool) {
-        get_from_memory::<bool>(this + 0x06E) = uses_placement_cube;
+    fn set_uses_placement_cube(&self, uses_placement_cube: bool) {
+        unsafe {
+            let uses_placement_cube_ptr: *mut bool = (self.this + 0x06E) as *mut bool;
+            *uses_placement_cube_ptr = uses_placement_cube;
+        }
     }
 
-    fn get_show() -> bool {
-        get_from_memory::<bool>(this + 0x06F)
+    fn get_show(&self) -> bool {
+        get_from_memory::<bool>(self.this + 0x06F)
     }
 
-    fn set_show(show: bool) {
-        get_from_memory::<bool>(this + 0x06F) = show;
+    fn set_show(&self, show: bool) {
+        unsafe {
+            let show_ptr: *mut bool = (self.this + 0x06F) as *mut bool;
+            *show_ptr = show;
+        }
     }
 
-    fn get_hit_threshold() -> u32 {
-        get_from_memory::<u32>(this + 0x070)
+    fn get_hit_threshold(&self) -> u32 {
+        get_from_memory::<u32>(self.this + 0x070)
     }
 
-    fn set_hit_threshold(hit_threshold: u32) {
-        get_from_memory::<u32>(this + 0x070) = hit_threshold;
+    fn set_hit_threshold(&self, hit_threshold: u32) {
+        unsafe {
+            let hit_threshold_ptr: *mut u32 = (self.this + 0x070) as *mut u32;
+            *hit_threshold_ptr = hit_threshold;
+        }
     }
 
-    fn get_avoid_edges() -> bool {
-        get_from_memory::<bool>(this + 0x074)
+    fn get_avoid_edges(&self) -> bool {
+        get_from_memory::<bool>(self.this + 0x074)
     }
 
-    fn set_avoid_edges(avoid_edges: bool) {
-        get_from_memory::<bool>(this + 0x074) = avoid_edges;
+    fn set_avoid_edges(&self, avoid_edges: bool) {
+        unsafe {
+            let avoid_edges_ptr: *mut bool = (self.this + 0x074) as *mut bool;
+            *avoid_edges_ptr = avoid_edges;
+        }
     }
 
-    fn get_type_name() -> String {
-        get_string_from_memory(this + 0x0A4)
+    fn get_type_name(&self) -> String {
+        let type_name_ptr = get_from_memory::<u32>(self.this + 0x0A4);
+        get_string_from_memory(type_name_ptr)
     }
 
-    fn set_type_name(type_name: String) {
-        get_from_memory::<String>(this + 0x0A4) = type_name;
+    fn set_type_name(&self, type_name: String) {
+        unsafe {
+            let type_name_ptr: *mut String = (self.this + 0x0A4) as *mut String;
+            *type_name_ptr = type_name;
+        }
     }
 
-    fn get_codename() -> String {
-        get_string_from_memory(this + 0x098)
+    fn get_codename(&self) -> String {
+        let codename_ptr = get_from_memory::<u32>(self.this + 0x098);
+        get_string_from_memory(codename_ptr)
     }
 
-    fn set_codename(codename: String) {
-        get_from_memory::<String>(this + 0x098) = codename;
+    fn set_codename(&self, codename: String) {
+        unsafe {
+            let codename_ptr: *mut String = (self.this + 0x098) as *mut String;
+            *codename_ptr = codename;
+        }
     }
 
-    fn get_footprintx() -> u32 {
-        get_from_memory::<u32>(this + 0x0B4)
+    fn get_footprintx(&self) -> u32 {
+        get_from_memory::<u32>(self.this + 0x0B4)
     }
 
-    fn set_footprintx(footprintx: u32) {
-        get_from_memory::<u32>(this + 0x0B4) = footprintx;
+    fn set_footprintx(&self, footprintx: u32) {
+        unsafe {
+            let footprintx_ptr: *mut u32 = (self.this + 0x0B4) as *mut u32;
+            *footprintx_ptr = footprintx;
+        }
     }
 
-    fn get_footprinty() -> u32 {
-        get_from_memory::<u32>(this + 0x0B8)
+    fn get_footprinty(&self) -> u32 {
+        get_from_memory::<u32>(self.this + 0x0B8)
     }
 
-    fn set_footprinty(footprinty: u32) {
-        get_from_memory::<u32>(this + 0x0B8) = footprinty;
+    fn set_footprinty(&self, footprinty: u32) {
+        unsafe {
+            let footprinty_ptr: *mut u32 = (self.this + 0x0B8) as *mut u32;
+            *footprinty_ptr = footprinty;
+        }
     }
 
-    fn get_footprintz() -> u32 {
-        get_from_memory::<u32>(this + 0x0BC)
+    fn get_footprintz(&self) -> u32 {
+        get_from_memory::<u32>(self.this + 0x0BC)
     }
 
-    fn set_footprintz(footprintz: u32) {
-        get_from_memory::<u32>(this + 0x0BC) = footprintz;
+    fn set_footprintz(&self, footprintz: u32) {
+        unsafe {
+            let footprintz_ptr: *mut u32 = (self.this + 0x0BC) as *mut u32;
+            *footprintz_ptr = footprintz;
+        }
     }
 
-    fn get_placement_footprintx() -> u32 {
-        get_from_memory::<u32>(this + 0x0C0)
+    fn get_placement_footprintx(&self) -> u32 {
+        get_from_memory::<u32>(self.this + 0x0C0)
     }
 
-    fn set_placement_footprintx(placement_footprintx: u32) {
-        get_from_memory::<u32>(this + 0x0C0) = placement_footprintx;
+    fn set_placement_footprintx(&self, placement_footprintx: u32) {
+        unsafe {
+            let placement_footprintx_ptr: *mut u32 = (self.this + 0x0C0) as *mut u32;
+            *placement_footprintx_ptr = placement_footprintx;
+        }
     }
 
-    fn get_placement_footprinty() -> u32 {
-        get_from_memory::<u32>(this + 0x0C4)
+    fn get_placement_footprinty(&self) -> u32 {
+        get_from_memory::<u32>(self.this + 0x0C4)
     }
 
-    fn set_placement_footprinty(placement_footprinty: u32) {
-        get_from_memory::<u32>(this + 0x0C4) = placement_footprinty;
+    fn set_placement_footprinty(&self, placement_footprinty: u32) {
+        unsafe {
+            let placement_footprinty_ptr: *mut u32 = (self.this + 0x0C4) as *mut u32;
+            *placement_footprinty_ptr = placement_footprinty;
+        }
     }
 
-    fn get_placement_footprintz() -> u32 {
-        get_from_memory::<u32>(this + 0x0C8)
+    fn get_placement_footprintz(&self) -> i32 {
+        get_from_memory::<i32>(self.this + 0x0C8)
     }
 
-    fn set_placement_footprintz(placement_footprintz: u32) {
-        get_from_memory::<u32>(this + 0x0C8) = placement_footprintz;
+    fn set_placement_footprintz(&self, placement_footprintz: i32) {
+        unsafe {
+            let placement_footprintz_ptr: *mut i32 = (self.this + 0x0C8) as *mut i32;
+            *placement_footprintz_ptr = placement_footprintz;
+        }
     }
 
-    fn get_available_at_startup() -> bool {
-        get_from_memory::<bool>(this + 0x0CC)
+    fn get_available_at_startup(&self) -> bool {
+        get_from_memory::<bool>(self.this + 0x0CC)
     }
 
-    fn set_available_at_startup(available_at_startup: bool) {
-        get_from_memory::<bool>(this + 0x0CC) = available_at_startup;
+    fn set_available_at_startup(&self, available_at_startup: bool) {
+        unsafe {
+            let available_at_startup_ptr: *mut bool = (self.this + 0x0CC) as *mut bool;
+            *available_at_startup_ptr = available_at_startup;
+        }
     }
+
+}
+
+pub fn command_print_configuration(_args: Vec<&str>) -> Result<String, &'static str> {
+    
+    let entity_type_address = get_selected_entity_type();
+    let entity_type_ptr = get_from_memory::<u32>(entity_type_address);
+    if entity_type_ptr == 0 {
+        return Err("No entity selected");
+    }
+    let entity_type = EntityType::new(entity_type_address);
+    info!("Printing configuration for entity type at address {:#x}", entity_type_ptr);
+  
+    Ok(format!("\n\n[Details]\nEntityType: {:#x}\nType Name: {}\nCodename: {}\n\n[Printed configuration]\nncolors: {}\ncIconZoom: {}\ncExpansionID: {}\ncMovable: {}\ncWalkable: {}\ncWalkableByTall: {}\ncRubbleable: {}\ncUseNumbersInName: {}\ncUsesRealShadows: {}\ncHasShadowImages: {}\ncForceShadowBlack: {}\ncDrawsLate: {}\ncHeight: {}\ncDepth: {}\ncHasUnderwaterSection: {}\ncIsTransient: {}\ncUsesPlacementCube: {}\ncShow: {}\ncHitThreshold: {}\ncAvoidEdges: {}\ncFootprintX: {}\ncFootprintY: {}\ncFootprintZ: {}\ncPlacementFootprintX: {}\ncPlacementFootprintY: {}\ncPlacementFootprintZ: {}\ncAvailableAtStartup: {}\n",
+        entity_type.this,
+        entity_type.get_type_name(),
+        entity_type.get_codename(),
+        entity_type.get_ncolors(),
+        entity_type.get_icon_zoom() as u32,
+        entity_type.get_expansion_id() as u32,
+        entity_type.get_movable() as u32,
+        entity_type.get_walkable() as u32,
+        entity_type.get_walkable_by_tall() as u32,
+        entity_type.get_rubbleable() as u32,
+        entity_type.get_use_numbers_in_name() as u32,
+        entity_type.get_uses_real_shadows() as u32,
+        entity_type.get_has_shadow_images() as u32,
+        entity_type.get_force_shadow_black() as u32,
+        entity_type.get_draws_late() as u32,
+        entity_type.get_height(),
+        entity_type.get_depth(),
+        entity_type.get_has_underwater_section() as u32,
+        entity_type.get_is_transient() as u32,
+        entity_type.get_uses_placement_cube() as u32,
+        entity_type.get_show() as u32,
+        entity_type.get_hit_threshold(),
+        entity_type.get_avoid_edges() as u32,
+        entity_type.get_footprintx(),
+        entity_type.get_footprinty(),
+        entity_type.get_footprintz(),
+        entity_type.get_placement_footprintx(),
+        entity_type.get_placement_footprinty(),
+        entity_type.get_placement_footprintz(),
+        entity_type.get_available_at_startup() as u32
+     ))
+}
+
+pub fn init() {
+    add_to_command_register("print_selected_configuration".to_string(), command_print_configuration);
 }

--- a/src/bfentitytype.rs
+++ b/src/bfentitytype.rs
@@ -405,7 +405,7 @@ impl BFEntityType for EntityType {
 
 }
 
-pub fn command_print_configuration(_args: Vec<&str>) -> Result<String, &'static str> {
+pub fn command_selected_type(_args: Vec<&str>) -> Result<String, &'static str> {
     
     let entity_type_address = get_selected_entity_type();
     let entity_type_ptr = get_from_memory::<u32>(entity_type_address);
@@ -413,42 +413,164 @@ pub fn command_print_configuration(_args: Vec<&str>) -> Result<String, &'static 
         return Err("No entity selected");
     }
     let entity_type = EntityType::new(entity_type_address);
-    info!("Printing configuration for entity type at address {:#x}", entity_type_ptr);
-  
-    Ok(format!("\n\n[Details]\nEntityType: {:#x}\nType Name: {}\nCodename: {}\n\n[Printed configuration]\nncolors: {}\ncIconZoom: {}\ncExpansionID: {}\ncMovable: {}\ncWalkable: {}\ncWalkableByTall: {}\ncRubbleable: {}\ncUseNumbersInName: {}\ncUsesRealShadows: {}\ncHasShadowImages: {}\ncForceShadowBlack: {}\ncDrawsLate: {}\ncHeight: {}\ncDepth: {}\ncHasUnderwaterSection: {}\ncIsTransient: {}\ncUsesPlacementCube: {}\ncShow: {}\ncHitThreshold: {}\ncAvoidEdges: {}\ncFootprintX: {}\ncFootprintY: {}\ncFootprintZ: {}\ncPlacementFootprintX: {}\ncPlacementFootprintY: {}\ncPlacementFootprintZ: {}\ncAvailableAtStartup: {}\n",
-        entity_type.this,
-        entity_type.get_type_name(),
-        entity_type.get_codename(),
-        entity_type.get_ncolors(),
-        entity_type.get_icon_zoom() as u32,
-        entity_type.get_expansion_id() as u32,
-        entity_type.get_movable() as u32,
-        entity_type.get_walkable() as u32,
-        entity_type.get_walkable_by_tall() as u32,
-        entity_type.get_rubbleable() as u32,
-        entity_type.get_use_numbers_in_name() as u32,
-        entity_type.get_uses_real_shadows() as u32,
-        entity_type.get_has_shadow_images() as u32,
-        entity_type.get_force_shadow_black() as u32,
-        entity_type.get_draws_late() as u32,
-        entity_type.get_height(),
-        entity_type.get_depth(),
-        entity_type.get_has_underwater_section() as u32,
-        entity_type.get_is_transient() as u32,
-        entity_type.get_uses_placement_cube() as u32,
-        entity_type.get_show() as u32,
-        entity_type.get_hit_threshold(),
-        entity_type.get_avoid_edges() as u32,
-        entity_type.get_footprintx(),
-        entity_type.get_footprinty(),
-        entity_type.get_footprintz(),
-        entity_type.get_placement_footprintx(),
-        entity_type.get_placement_footprinty(),
-        entity_type.get_placement_footprintz(),
-        entity_type.get_available_at_startup() as u32
-     ))
+    if _args.len() == 0 {
+        return Ok(format!("Entity type at address {:#x}", entity_type_ptr));
+    }
+    if _args[0] == "-v" {
+
+        info!("Printing configuration for entity type at address {:#x}", entity_type_ptr);
+    
+        Ok(format!("\n\n[Details]\nEntityType: {:#x}\nType Name: {}\nCodename: {}\n\n[Printed configuration]\nncolors: {}\ncIconZoom: {}\ncExpansionID: {}\ncMovable: {}\ncWalkable: {}\ncWalkableByTall: {}\ncRubbleable: {}\ncUseNumbersInName: {}\ncUsesRealShadows: {}\ncHasShadowImages: {}\ncForceShadowBlack: {}\ncDrawsLate: {}\ncHeight: {}\ncDepth: {}\ncHasUnderwaterSection: {}\ncIsTransient: {}\ncUsesPlacementCube: {}\ncShow: {}\ncHitThreshold: {}\ncAvoidEdges: {}\ncFootprintX: {}\ncFootprintY: {}\ncFootprintZ: {}\ncPlacementFootprintX: {}\ncPlacementFootprintY: {}\ncPlacementFootprintZ: {}\ncAvailableAtStartup: {}\n",
+            entity_type.this,
+            entity_type.get_type_name(),
+            entity_type.get_codename(),
+            entity_type.get_ncolors(),
+            entity_type.get_icon_zoom() as u32,
+            entity_type.get_expansion_id() as u32,
+            entity_type.get_movable() as u32,
+            entity_type.get_walkable() as u32,
+            entity_type.get_walkable_by_tall() as u32,
+            entity_type.get_rubbleable() as u32,
+            entity_type.get_use_numbers_in_name() as u32,
+            entity_type.get_uses_real_shadows() as u32,
+            entity_type.get_has_shadow_images() as u32,
+            entity_type.get_force_shadow_black() as u32,
+            entity_type.get_draws_late() as u32,
+            entity_type.get_height(),
+            entity_type.get_depth(),
+            entity_type.get_has_underwater_section() as u32,
+            entity_type.get_is_transient() as u32,
+            entity_type.get_uses_placement_cube() as u32,
+            entity_type.get_show() as u32,
+            entity_type.get_hit_threshold(),
+            entity_type.get_avoid_edges() as u32,
+            entity_type.get_footprintx(),
+            entity_type.get_footprinty(),
+            entity_type.get_footprintz(),
+            entity_type.get_placement_footprintx(),
+            entity_type.get_placement_footprinty(),
+            entity_type.get_placement_footprintz(),
+            entity_type.get_available_at_startup() as u32
+        ))
+    }
+    else if _args.len() == 2 {
+        if _args[0] == "-ncolors" {
+            entity_type.set_ncolors(_args[1].parse::<u32>().unwrap());
+            return Ok(format!("ncolors set to {}", _args[1]));
+        }
+        else if _args[0] == "-cIconZoom" {
+            entity_type.set_icon_zoom(_args[1].parse::<bool>().unwrap());
+            return Ok(format!("cIconZoom set to {}", _args[1]));
+        }
+        else if _args[0] == "-cExpansionID" {
+            entity_type.set_expansion_id(_args[1].parse::<bool>().unwrap());
+            return Ok(format!("cExpansionID set to {}", _args[1]));
+        }
+        else if _args[0] == "-cMovable" {
+            entity_type.set_movable(_args[1].parse::<bool>().unwrap());
+            return Ok(format!("cMovable set to {}", _args[1]));
+        }
+        else if _args[0] == "-cWalkable" {
+            entity_type.set_walkable(_args[1].parse::<bool>().unwrap());
+            return Ok(format!("cWalkable set to {}", _args[1]));
+        }
+        else if _args[0] == "-cWalkableByTall" {
+            entity_type.set_walkable_by_tall(_args[1].parse::<bool>().unwrap());
+            return Ok(format!("cWalkableByTall set to {}", _args[1]));
+        }
+        else if _args[0] == "-cRubbleable" {
+            entity_type.set_rubbleable(_args[1].parse::<bool>().unwrap());
+            return Ok(format!("cRubbleable set to {}", _args[1]));
+        }
+        else if _args[0] == "-cUseNumbersInName" {
+            entity_type.set_use_numbers_in_name(_args[1].parse::<bool>().unwrap());
+            return Ok(format!("cUseNumbersInName set to {}", _args[1]));
+        }
+        else if _args[0] == "-cUsesRealShadows" {
+            entity_type.set_uses_real_shadows(_args[1].parse::<bool>().unwrap());
+            return Ok(format!("cUsesRealShadows set to {}", _args[1]));
+        }
+        else if _args[0] == "-cHasShadowImages" {
+            entity_type.set_has_shadow_images(_args[1].parse::<bool>().unwrap());
+            return Ok(format!("cHasShadowImages set to {}", _args[1]));
+        }
+        else if _args[0] == "-cForceShadowBlack" {
+            entity_type.set_force_shadow_black(_args[1].parse::<bool>().unwrap());
+            return Ok(format!("cForceShadowBlack set to {}", _args[1]));
+        }
+        else if _args[0] == "-cDrawsLate" {
+            entity_type.set_draws_late(_args[1].parse::<bool>().unwrap());
+            return Ok(format!("cDrawsLate set to {}", _args[1]));
+        }
+        else if _args[0] == "-cHeight" {
+            entity_type.set_height(_args[1].parse::<u32>().unwrap());
+            return Ok(format!("cHeight set to {}", _args[1]));
+        }
+        else if _args[0] == "-cDepth" {
+            entity_type.set_depth(_args[1].parse::<u32>().unwrap());
+            return Ok(format!("cDepth set to {}", _args[1]));
+        }
+        else if _args[0] == "-cHasUnderwaterSection" {
+            entity_type.set_has_underwater_section(_args[1].parse::<bool>().unwrap());
+            return Ok(format!("cHasUnderwaterSection set to {}", _args[1]));
+        }
+        else if _args[0] == "-cIsTransient" {
+            entity_type.set_is_transient(_args[1].parse::<bool>().unwrap());
+            return Ok(format!("cIsTransient set to {}", _args[1]));
+        }
+        else if _args[0] == "-cUsesPlacementCube" {
+            entity_type.set_uses_placement_cube(_args[1].parse::<bool>().unwrap());
+            return Ok(format!("cUsesPlacementCube set to {}", _args[1]));
+        }
+        else if _args[0] == "-cShow" {
+            entity_type.set_show(_args[1].parse::<bool>().unwrap());
+            return Ok(format!("cShow set to {}", _args[1]));
+        }
+        else if _args[0] == "-cHitThreshold" {
+            entity_type.set_hit_threshold(_args[1].parse::<u32>().unwrap());
+            return Ok(format!("cHitThreshold set to {}", _args[1]));
+        }
+        else if _args[0] == "-cAvoidEdges" {
+            entity_type.set_avoid_edges(_args[1].parse::<bool>().unwrap());
+            return Ok(format!("cAvoidEdges set to {}", _args[1]));
+        }
+        else if _args[0] == "-cFootprintX" {
+            entity_type.set_footprintx(_args[1].parse::<u32>().unwrap());
+            return Ok(format!("cFootprintX set to {}", _args[1]));
+        }
+        else if _args[0] == "-cFootprintY" {
+            entity_type.set_footprinty(_args[1].parse::<u32>().unwrap());
+            return Ok(format!("cFootprintY set to {}", _args[1]));
+        }
+        else if _args[0] == "-cFootprintZ" {
+            entity_type.set_footprintz(_args[1].parse::<u32>().unwrap());
+            return Ok(format!("cFootprintZ set to {}", _args[1]));
+        }
+        else if _args[0] == "-cPlacementFootprintX" {
+            entity_type.set_placement_footprintx(_args[1].parse::<u32>().unwrap());
+            return Ok(format!("cPlacementFootprintX set to {}", _args[1]));
+        }
+        else if _args[0] == "-cPlacementFootprintY" {
+            entity_type.set_placement_footprinty(_args[1].parse::<u32>().unwrap());
+            return Ok(format!("cPlacementFootprintY set to {}", _args[1]));
+        }
+        else if _args[0] == "-cPlacementFootprintZ" {
+            entity_type.set_placement_footprintz(_args[1].parse::<i32>().unwrap());
+            return Ok(format!("cPlacementFootprintZ set to {}", _args[1]));
+        }
+        else if _args[0] == "-cAvailableAtStartup" {
+            entity_type.set_available_at_startup(_args[1].parse::<bool>().unwrap());
+            return Ok(format!("cAvailableAtStartup set to {}", _args[1]));
+        }
+        else {
+            return Ok("Invalid argument".to_string());
+        }
+    }
+    else {
+        Ok("Invalid argument".to_string())
+    }
 }
 
 pub fn init() {
-    add_to_command_register("print_selected_configuration".to_string(), command_print_configuration);
+    add_to_command_register("selected_type".to_string(), command_selected_type);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@ mod ztadvterrainmgr;
 
 mod expansions;
 
+mod bfentitytype;
+
 #[cfg(target_os = "windows")]
 use winapi::um::winnt::{DLL_PROCESS_ATTACH, DLL_PROCESS_DETACH, DLL_THREAD_ATTACH, DLL_THREAD_DETACH};
 
@@ -199,6 +201,7 @@ extern "system" fn DllMain(module: u8, reason: u32, _reserved: u8) -> i32 {
                 ztworldmgr::init();
                 resource_manager::init();
                 expansions::init();
+                bfentitytype::init();
             }
 
         }

--- a/src/ztui.rs
+++ b/src/ztui.rs
@@ -18,4 +18,21 @@ fn command_get_selected_entity(_args: Vec<&str>) -> Result<String, &'static str>
     Ok(format!("{:#?}", entity))
 }
 
+// returns the address of the selected entity
+pub fn get_selected_entity() -> u32 {
+    let get_selected_entity_fn = unsafe { std::mem::transmute::<u32, fn() -> u32>(0x00410f84) };
+    get_selected_entity_fn()
+}
+
+// returns the address of the selected entity type
+pub fn get_selected_entity_type() -> u32 {
+    let selected_entity = get_selected_entity();
+    if selected_entity == 0 {
+        return 0;
+    }
+
+    let entity_type_address = selected_entity + 0x128;
+    entity_type_address
+}
+
 


### PR DESCRIPTION
## Implementation Details  
Adds a struct for EntityTypes with the following implemented pointer traits:  

- get_ncolors
- set_ncolors
- get_icon_zoom
- set_icon_zoom
- get_expansion_id
- set_expansion_id
- get_movable
- set_movable
- get_walkable
- set_walkable
- get_walkable_by_tall
- set_walkable_by_tall
- get_rubbleable
- set_rubbleable
- get_use_numbers_in_name
- set_use_numbers_in_name
- get_uses_real_shadows
- set_uses_real_shadows
- get_has_shadow_images
- set_has_shadow_images
- get_force_shadow_black
- set_force_shadow_black
- get_draws_late
- set_draws_late
- get_height
- set_height
- get_depth
- set_depth
- get_has_underwater_section
- set_has_underwater_section
- get_is_transient
- set_is_transient
- get_uses_placement_cube
- set_uses_placement_cube
- get_show
- set_show
- get_hit_threshold
- set_hit_threshold
- get_avoid_edges
- set_avoid_edges
- get_type_name
- set_type_name
- get_codename
- set_codename
- get_footprintx
- set_footprintx
- get_footprinty
- set_footprinty
- get_footprintz
- set_footprintz
- get_placement_footprintx
- set_placement_footprintx
- get_placement_footprinty
- set_placement_footprinty
- get_placement_footprintz
- set_placement_footprintz
- get_available_at_startup
- set_available_at_startup
- new  

## Usage  
To operate on an EntityType, call `EntityType::new(<u32>)` and any of the above functions can be used.  

## Console Commands  
Added a console command with the following arguments:  

### Arguments
`selected_type` -> returns address to type in memory  

#### Subarguments:  

`-v` prints all set configuration for this type
- `-ncolors <u32>`: Sets the number of colors for the selected entity type
- `-cIconZoom <bool>`: Sets the icon zoom for the selected entity type
- `-cExpansionID <bool>`: Sets the expansion ID for the selected entity type
- `-cMovable <bool>`: Sets the movable property for the selected entity type
- `-cWalkable <bool>`: Sets the walkable property for the selected entity type
- `-cWalkableByTall <bool>`: Sets the walkable by tall property for the selected entity type
- `-cRubbleable <bool>`: Sets the rubbleable property for the selected entity type
- `-cUseNumbersInName <bool>`: Sets the use numbers in name property for the selected entity type
- `-cUsesRealShadows <bool>`: Sets the uses real shadows property for the selected entity type
- `-cHasShadowImages <bool>`: Sets the has shadow images property for the selected entity type
- `-cForceShadowBlack <bool>`: Sets the force shadow black property for the selected entity type
- `-cDrawsLate <bool>`: Sets the draws late property for the selected entity type
- `-cHeight <bool>`: Sets the height for the selected entity type
- `-cDepth <bool>`: Sets the depth for the selected entity type
- `-cHasUnderwaterSection <bool>`: Sets the has underwater section property for the selected entity type
- `-cIsTransient <bool>`: Sets the is transient property for the selected entity type
- `-cUsesPlacementCube <bool>`: Sets the uses placement cube property for the selected entity type
- `-cShow <bool>`: Sets the show property for the selected entity type
- `-cHitThreshold <bool>`: Sets the hit threshold for the selected entity type
- `-cAvoidEdges <bool>`: Sets the avoid edges property for the selected entity type
- `-cFootprintX <u32>`: Sets the footprint x for the selected entity type
- `-cFootprintY <u32>`: Sets the footprint y for the selected entity type
- `-cFootprintZ <u32>`: Sets the footprint z for the selected entity type
- `-cPlacementFootprintX <u32>`: Sets the placement footprint x for the selected entity type
- `-cPlacementFootprintY <u32>`: Sets the placement footprint y for the selected entity type
- `-cPlacementFootprintZ <u32>`: Sets the placement footprint z for the selected entity type
- `-cAvailableAtStartup <bool>`: Sets the available at startup property for the selected entity type  

## Considerations:  
- `set_codename`, `set_type_name`, and `set_ncolors` are currently not implemented and will be corrected in a future PR.