### PR TITLE
refactored gamemgr to address previous concerns

### DIFF
--- a/src/ztgamemgr.rs
+++ b/src/ztgamemgr.rs
@@ -1,13 +1,9 @@
 // ztgamemgr module has functions to interact with the live zoo stats such as cash, num animals, species, guests, etc.
 
 use crate::add_to_command_register;
-use crate::debug_dll::{get_from_memory, get_string_from_memory};
+use crate::debug_dll::get_from_memory;
 
 use tracing::info;
-use std::collections::HashMap;
-use std::fmt;
-use std::fmt::Display;
-use num_enum::FromPrimitive;
 
 const GLOBAL_ZTGAMEMGR_ADDRESS: u32 = 0x00638048;
 
@@ -15,26 +11,31 @@ const GLOBAL_ZTGAMEMGR_ADDRESS: u32 = 0x00638048;
 #[derive(Debug)]
 #[repr(C)]
 struct ZTGameMgr {
-    instance: u32, // 0x0
-    get_date: String, // 0x1194 (8 bytes)
-    get_cash: f32, // 0x0C
-    set_cash: f32, // 0x0C
-    add_cash: f32, // 0x0C
-    sub_cash: f32, // 0x0C
-    num_animals: u32, // 0x30
-    num_species: u32, // 0x38
-    num_guests: u32, // 0x54
-    num_tired_guests: u32, // 0x3C
-    num_hungry_guests: u32, // 0x40
-    num_thirst_guests: u32, // 0x44
-    num_guests_restroom_need: u32, // 0x48
-    num_guests_in_filter: u32, // 0x54
+    pad1: [u8; 0x0C],
+    cash: f32, // 0x0C
+    pad2: [u8; 0x30 - 0x10], // 0x0C
+    num_animals: u16, // 0x30
+    pad3: [u8; 0x38 - 0x32], // 0x30
+    num_species: u16, // 0x38
+    pad4: [u8; 0x3C - 0x3A], // 0x38
+    num_tired_guests: u16, // 0x3C
+    pad5: [u8; 0x40 - 0x3E], // 0x3C
+    num_hungry_guests: u16, // 0x40
+    pad6: [u8; 0x44 - 0x42], // 0x40
+    num_thirst_guests: u16, // 0x44
+    pad7: [u8; 0x48 - 0x46], // 0x44
+    num_guests_restroom_need: u16, // 0x48
+    pad8: [u8; 0x54 - 0x4A], // 0x48
+    num_guests: u16, // 0x54
+    pad9: [u8; 0x1160 - 0x56], // 0x54
     zoo_admission_cost: f32, // 0x1160
-    enable_dev_mode: bool, // 0x63858A
+    pad10: [u8; 0x1194 - 0x1164], // 0x1160
+    date: SYSTEMTIME, // 0x1194
+    pad11: [u8; 0x1400], // 0x1194
 }
 
 // SYSTEMTIME struct from Windows API
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[repr(C)]
 struct SYSTEMTIME {
     w_year: u16,
@@ -47,88 +48,12 @@ struct SYSTEMTIME {
     w_milliseconds: u16,
 }
 
-impl ZTGameMgr {
-    // returns the address of the ZTGameMgr instance in memory
-    fn instance() -> u32 {
-        get_from_memory::<u32>(GLOBAL_ZTGAMEMGR_ADDRESS)
-    }
+struct GameMgr {
+    enable_dev_mode: fn(bool) -> String,
+    instance: fn() -> Option<&'static GameMgr>,
+}
 
-    // returns the SYSTEMTIME struct in memory
-    fn get_date() -> SYSTEMTIME {
-        let date = get_from_memory::<SYSTEMTIME>(Self::instance() + 0x1194);
-        date
-    }
-
-    // returns the cash in the player's account
-    fn get_cash() -> f32 {
-        get_from_memory::<f32>(Self::instance() + 0x0C)
-    }
-
-    // sets the cash in the player's account
-    fn set_cash(cash: f32) {
-        let cash_address = Self::instance() + 0x0C;
-        unsafe {
-            *(cash_address as *mut f32) = cash;
-        }
-    }
-
-    // adds cash to the player's account
-    fn add_cash(cash: f32) {
-        let current_cash = Self::get_cash();
-        Self::set_cash(current_cash + cash);
-    }
-
-    // subtracts cash from the player's account
-    fn sub_cash(cash: f32) {
-        let current_cash = Self::get_cash();
-        Self::set_cash(current_cash - cash);
-    }
-
-    // returns the number of animals in the zoo
-    fn num_animals() -> u32 {
-        get_from_memory::<u32>(Self::instance() + 0x30)
-    }
-
-    // returns the number of species in the zoo
-    fn num_species() -> u32 {
-        get_from_memory::<u32>(Self::instance() + 0x38)
-    }
-
-    // returns the number of guests in the zoo
-    fn num_guests() -> u32 {
-        get_from_memory::<u32>(Self::instance() + 0x54)
-    }
-
-    // returns the number of tired guests in the zoo
-    fn num_tired_guests() -> u32 {
-        get_from_memory::<u32>(Self::instance() + 0x3C)
-    }
-
-    // returns the number of hungry guests in the zoo
-    fn num_hungry_guests() -> u32 {
-        get_from_memory::<u32>(Self::instance() + 0x40)
-    }
-
-    // returns the number of thirsty guests in the zoo
-    fn num_thirst_guests() -> u32 {
-        get_from_memory::<u32>(Self::instance() + 0x44)
-    }
-
-    // returns the number of guests that need to use the restroom
-    fn num_guests_restroom_need() -> u32 {
-        get_from_memory::<u32>(Self::instance() + 0x48)
-    }
-
-    // returns the number of guests in the filter
-    fn num_guests_in_filter() -> u32 {
-        get_from_memory::<u32>(Self::instance() + 0x54)
-    }
-
-    // returns the zoo admission cost
-    fn zoo_admission_cost() -> f32 {
-        get_from_memory::<f32>(Self::instance() + 0x1160)
-    }
-
+impl GameMgr {
     // enables or disables dev mode
     fn enable_dev_mode(enable: bool) {
         let enable_dev_mode_address = 0x63858A;
@@ -136,13 +61,30 @@ impl ZTGameMgr {
             *(enable_dev_mode_address as *mut bool) = enable;
         }
     }
+
+    // returns the instance of the ZTGameMgr struct
+    fn instance() -> Option<&'static mut ZTGameMgr> {
+        unsafe {
+            // get the pointer to the ZTGameMgr instance    
+            let ptr = get_from_memory::<*mut ZTGameMgr>(GLOBAL_ZTGAMEMGR_ADDRESS);
+    
+            // is pointer null
+            if !ptr.is_null() {
+                Some(&mut *ptr)
+            } 
+            else {
+                // pointer is null
+                None
+            }
+        }
+    }
 }
 
 // prints the SYSTEMTIME struct in memory in a human-readable format
 // usage: get_date
 pub fn command_get_date_str(_args: Vec<&str>) -> Result<String, &'static str> {
-    let date = get_from_memory::<SYSTEMTIME>(ZTGameMgr::instance() + 0x1194);
-
+    let ztgamemgr = GameMgr::instance().unwrap();
+    let date = ztgamemgr.date.clone();
     info!("Date: {:#?}", date);
 
     Ok(format!("{:04}-{:02}-{:02} {:02}:{:02}:{:02}", date.w_year, date.w_month, date.w_day, date.w_hour, date.w_minute, date.w_second))
@@ -151,23 +93,24 @@ pub fn command_get_date_str(_args: Vec<&str>) -> Result<String, &'static str> {
 // adds cash to the player's account
 // usage: add_cash <amount>
 pub fn command_add_cash(_args: Vec<&str>) -> Result<String, &'static str> {
-    let cash = _args[0].parse::<f32>().unwrap();
-    ZTGameMgr::add_cash(cash);
-    Ok(format!("Added ${}", cash))
+    let ztgamemgr = GameMgr::instance().unwrap();
+    ztgamemgr.cash += _args[0].parse::<f32>().unwrap();
+    Ok(format!("Added ${}", _args[0]))
 }
 
 // enables or disables dev mode
 // usage: enable_dev_mode <true/false>
 pub fn command_enable_dev_mode(_args: Vec<&str>) -> Result<String, &'static str> {
     let enable = _args[0].parse::<bool>().unwrap();
-    ZTGameMgr::enable_dev_mode(enable);
+    GameMgr::enable_dev_mode(enable);
     Ok(format!("Dev mode enabled: {}", enable))
 }
 
 // prints various stats about the zoo
 // usage: zoostats
 pub fn command_zoostats(_args: Vec<&str>) -> Result<String, &'static str> {
-    Ok(format!("\nBudget: {}\nAnimals: {}\nSpecies: {}\nGuests: {}\nTired Guests: {}\nHungry Guests: {}\nThirsty Guests: {}\nGuests Need Restroom: {}\nGuests in Filter: {}\nZoo Admission Cost: ${}", ZTGameMgr::get_cash(), ZTGameMgr::num_animals(), ZTGameMgr::num_species(), ZTGameMgr::num_guests(), ZTGameMgr::num_tired_guests(), ZTGameMgr::num_hungry_guests(), ZTGameMgr::num_thirst_guests(), ZTGameMgr::num_guests_restroom_need(), ZTGameMgr::num_guests_in_filter(), ZTGameMgr::zoo_admission_cost()))
+    let ztgamemgr = GameMgr::instance().unwrap();
+    Ok(format!("\nBudget: {}\nAnimals: {}\nSpecies: {}\nTired Guests: {}\nHungry Guests: {}\nThirsty Guests: {}\nGuests Need Restroom: {}\nNum Guests: {}\nZoo Admission Cost: ${}", ztgamemgr.cash, ztgamemgr.num_animals, ztgamemgr.num_species, ztgamemgr.num_tired_guests, ztgamemgr.num_hungry_guests, ztgamemgr.num_thirst_guests, ztgamemgr.num_guests_restroom_need, ztgamemgr.num_guests, ztgamemgr.zoo_admission_cost))
 }
 
 // registers the commands with the command register

--- a/src/ztgamemgr.rs
+++ b/src/ztgamemgr.rs
@@ -48,12 +48,7 @@ struct SYSTEMTIME {
     w_milliseconds: u16,
 }
 
-struct GameMgr {
-    enable_dev_mode: fn(bool) -> String,
-    instance: fn() -> Option<&'static GameMgr>,
-}
-
-impl GameMgr {
+impl ZTGameMgr {
     // enables or disables dev mode
     fn enable_dev_mode(enable: bool) {
         let enable_dev_mode_address = 0x63858A;
@@ -83,7 +78,7 @@ impl GameMgr {
 // prints the SYSTEMTIME struct in memory in a human-readable format
 // usage: get_date
 pub fn command_get_date_str(_args: Vec<&str>) -> Result<String, &'static str> {
-    let ztgamemgr = GameMgr::instance().unwrap();
+    let ztgamemgr = ZTGameMgr::instance().unwrap();
     let date = ztgamemgr.date.clone();
     info!("Date: {:#?}", date);
 
@@ -93,7 +88,7 @@ pub fn command_get_date_str(_args: Vec<&str>) -> Result<String, &'static str> {
 // adds cash to the player's account
 // usage: add_cash <amount>
 pub fn command_add_cash(_args: Vec<&str>) -> Result<String, &'static str> {
-    let ztgamemgr = GameMgr::instance().unwrap();
+    let ztgamemgr = ZTGameMgr::instance().unwrap();
     ztgamemgr.cash += _args[0].parse::<f32>().unwrap();
     Ok(format!("Added ${}", _args[0]))
 }
@@ -102,14 +97,14 @@ pub fn command_add_cash(_args: Vec<&str>) -> Result<String, &'static str> {
 // usage: enable_dev_mode <true/false>
 pub fn command_enable_dev_mode(_args: Vec<&str>) -> Result<String, &'static str> {
     let enable = _args[0].parse::<bool>().unwrap();
-    GameMgr::enable_dev_mode(enable);
+    ZTGameMgr::enable_dev_mode(enable);
     Ok(format!("Dev mode enabled: {}", enable))
 }
 
 // prints various stats about the zoo
 // usage: zoostats
 pub fn command_zoostats(_args: Vec<&str>) -> Result<String, &'static str> {
-    let ztgamemgr = GameMgr::instance().unwrap();
+    let ztgamemgr = ZTGameMgr::instance().unwrap();
     Ok(format!("\nBudget: {}\nAnimals: {}\nSpecies: {}\nTired Guests: {}\nHungry Guests: {}\nThirsty Guests: {}\nGuests Need Restroom: {}\nNum Guests: {}\nZoo Admission Cost: ${}", ztgamemgr.cash, ztgamemgr.num_animals, ztgamemgr.num_species, ztgamemgr.num_tired_guests, ztgamemgr.num_hungry_guests, ztgamemgr.num_thirst_guests, ztgamemgr.num_guests_restroom_need, ztgamemgr.num_guests, ztgamemgr.zoo_admission_cost))
 }
 


### PR DESCRIPTION
# Changes
- Removed all function pointers
- ZTGameMgr struct is now a memory reimplementation
- Moved `enabled_dev_mode` to its own impl 

# Usage
```Rust
let ztgamemgr = GameMgr::instance().unwrap();

// dates
let date = ztgamemgr.date; // get date variable
let month = date.w_month; // get month
etc

// cash access
let deposit = 30000.0;
ztgamemgr.cash += deposit ; // change value
Ok(format!("Added ${}", ztgamemgr.cash)); // access value
```