### PR TITLE
Implemented ZTAnimalType API

### DIFF
--- a/src/bfentitytype.rs
+++ b/src/bfentitytype.rs
@@ -1999,12 +1999,175 @@ impl ZTAnimalType {
             Ok(format!("Set Dirt Chance to {}", self.dirt_chance))
         } else if config == "-cWaterNeeded" {
             self.water_needed = value.parse::<i32>().unwrap();
-            Ok(format!("Set Water Need to {}", self.water_needed))
+            Ok(format!("Set Water Needed to {}", self.water_needed))
+        } else if config == "-cUnderwaterNeeded" {
+            self.underwater_needed = value.parse::<i32>().unwrap();
+            Ok(format!("Set Underwater Needed to {}", self.underwater_needed))
+        } else if config == "-cLandNeeded" {
+            self.land_needed = value.parse::<i32>().unwrap();
+            Ok(format!("Set Land Needed to {}", self.land_needed))
+        } else if config == "-cEnterWaterChance" {
+            self.enter_water_chance = value.parse::<i32>().unwrap();
+            Ok(format!("Set Enter Water Chance to {}", self.enter_water_chance))
+        } else if config == "-cEnterTankChance" {
+            self.enter_tank_chance = value.parse::<i32>().unwrap();
+            Ok(format!("Set Enter Tank Chance to {}", self.enter_tank_chance))
+        } else if config == "-cEnterLandChance" {
+            self.enter_land_chance = value.parse::<i32>().unwrap();
+            Ok(format!("Set Enter Land Chance to {}", self.enter_land_chance))
+        } else if config == "-cDrinkWaterChance" {
+            self.drink_water_chance = value.parse::<i32>().unwrap();
+            Ok(format!("Set Drink Water Chance to {}", self.drink_water_chance))
+        } else if config == "-cChaseAnimalChance" {
+            self.chase_animal_chance = value.parse::<i32>().unwrap();
+            Ok(format!("Set Chase Animal Chance to {}", self.chase_animal_chance))
+        } else if config == "-cClimbsCliffs" {
+            self.climbs_cliffs = value.parse::<i32>().unwrap();
+            Ok(format!("Set Climbs Cliffs to {}", self.climbs_cliffs))
+        } else if config == "-cBashStrength" {
+            self.bash_strength = value.parse::<i32>().unwrap();
+            Ok(format!("Set Bash Strength to {}", self.bash_strength))
+        } else if config == "-cAttractiveness" {
+            self.attractiveness = value.parse::<i32>().unwrap();
+            Ok(format!("Set Attractiveness to {}", self.attractiveness))
+        } else if config == "-cKeeperFoodType" {
+            self.keeper_food_type = value.parse::<i32>().unwrap();
+            Ok(format!("Set Keeper Food Type to {}", self.keeper_food_type))
+        } else if config == "-cIsClimber" {
+            self.is_climber = value.parse::<bool>().unwrap();
+            Ok(format!("Set Is Climber to {}", self.is_climber))
+        } else if config == "-cIsJumper" {
+            self.is_jumper = value.parse::<bool>().unwrap();
+            Ok(format!("Set Is Jumper to {}", self.is_jumper))
+        } else if config == "-cSmallZoodoo" {
+            self.small_zoodoo = value.parse::<i32>().unwrap();
+            Ok(format!("Set Small Zoodoo to {}", self.small_zoodoo))
+        } else if config == "-cDinoZoodoo" {
+            self.dino_zoodoo = value.parse::<i32>().unwrap();
+            Ok(format!("Set Dino Zoodoo to {}", self.dino_zoodoo))
+        } else if config == "-cGiantZoodoo" {
+            self.giant_zoodoo = value.parse::<i32>().unwrap();
+            Ok(format!("Set Giant Zoodoo to {}", self.giant_zoodoo))
+        } else if config == "-cIsSpecialAnimal" {
+            self.is_special_animal = value.parse::<bool>().unwrap();
+            Ok(format!("Set Is Special Animal to {}", self.is_special_animal))
+        } else if config == "-cNeedShelter" {
+            self.need_shelter = value.parse::<bool>().unwrap();
+            Ok(format!("Set Need Shelter to {}", self.need_shelter))
+        } else if config == "-cNeedToys" {
+            self.need_toys = value.parse::<bool>().unwrap();
+            Ok(format!("Set Need Toys to {}", self.need_toys))
+        } else if config == "-cBabiesAttack" {
+            self.babies_attack = value.parse::<bool>().unwrap();
+            Ok(format!("Set Babies Attack to {}", self.babies_attack))
         } else {
             Err("Invalid configuration option")
         }
+
+        pub fn print_config_integers(&self) -> String {
+        format!(
+            "Box Footprint X: {}\nBox Footprint Y: {}\nBox Footprint Z: {}\nFamily: {}\nGenus: {}\nHabitat: {}\nLocation: {}\nEra: {}\nBreath Threshold: {}\nBreath Increment: {}\nHunger Threshold: {}\nHungry Health Change: {}\nHunger Increment: {}\nFood Unit Value: {}\nKeeper Food Units Eaten: {}\nNeeded Food: {}\nNo Food Change: {}\nInitial Happiness: {}\nMax Hits: {}\nPct Hits: {}\nMax Energy: {}\nMax Dirty: {}\nMin Dirty: {}\nSick Change: {}\nOther Animal Sick Change: {}\nSick Chance: {}\nSick Random Chance: {}\nCrowd: {}\nCrowd Happiness Change: {}\nZap Happiness Change: {}\nCaptivity: {}\nReproduction Chance: {}\nReproduction Interval: {}\nMating Type: {}\nOffspring: {}\nKeeper Frequency: {}\nNot Enough Keepers Change: {}\nSocial: {}\nHabitat Size: {}\nNumber Animals Min: {}\nNumber Animals Max: {}\nNumber Min Change: {}\nNumber Max Change: {}\nHabitat Preference: {}\nBaby Born Change: {}\nEnergy Increment: {}\nEnergy Threshold: {}\nDirty Increment: {}\nDirty Threshold: {}\nSick Time: {}\nBaby To Adult: {}\nOther Food: {}\nTree Pref: {}\nRock Pref: {}\nSpace Pref: {}\nElevation Pref: {}\nDepth Min: {}\nDepth Max: {}\nDepth Change: {}\nSalinity Change: {}\nSalinity Health Change: {}\nHappy Reproduce Threshold: {}\nBuilding Use Chance: {}\nNo Mate Change: {}\nTime Death: {}\nDeath Chance: {}\nDirt Chance: {}\nWater Needed: {}\nUnderwater Needed: {}\nLand Needed: {}\nEnter Water Chance: {}\nEnter Tank Chance: {}\nEnter Land Chance: {}\nDrink Water Chance: {}\nChase Animal Chance: {}\nClimbs Cliffs: {}\nBash Strength: {}\nAttractiveness: {}\nKeeper Food Type: {}\nIs Climber: {}\nIs Jumper: {}\nSmall Zoodoo: {}\nDino Zoodoo: {}\nGiant Zoodoo: {}\nIs Special Animal: {}\
+            Need Shelter: {}\nNeed Toys: {}\nBabies Attack: {}\n",
+            self.box_footprint_x,
+            self.box_footprint_y,
+            self.box_footprint_z,
+            self.family,
+            self.genus,
+            self.habitat,
+            self.location,
+            self.era,
+            self.breath_threshold,
+            self.breath_increment,
+            self.hunger_threshold,
+            self.hungry_health_change,
+            self.hunger_increment,
+            self.food_unit_value,
+            self.keeper_food_units_eaten,
+            self.needed_food,
+            self.no_food_change,
+            self.initial_happiness,
+            self.max_hits,
+            self.pct_hits,
+            self.max_energy,
+            self.max_dirty,
+            self.min_dirty,
+            self.sick_change,
+            self.other_animal_sick_change,
+            self.sick_chance,
+            self.sick_random_chance,
+            self.crowd,
+            self.crowd_happiness_change,
+            self.zap_happiness_change,
+            self.captivity,
+            self.reproduction_chance,
+            self.reproduction_interval,
+            self.mating_type,
+            self.offspring,
+            self.keeper_frequency,
+            self.not_enough_keepers_change,
+            self.social,
+            self.habitat_size,
+            self.number_animals_min,
+            self.number_animals_max,
+            self.number_min_change,
+            self.number_max_change,
+            self.habitat_preference,
+            self.baby_born_change,
+            self.energy_increment,
+            self.energy_threshold,
+            self.dirty_increment,
+            self.dirty_threshold,
+            self.sick_time,
+            self.baby_to_adult,
+            self.other_food,
+            self.tree_pref,
+            self.rock_pref,
+            self.space_pref,
+            self.elevation_pref,
+            self.depth_min,
+            self.depth_max,
+            self.depth_change,
+            self.salinity_change,
+            self.salinity_health_change,
+            self.happy_reproduce_threshold,
+            self.building_use_chance,
+            self.no_mate_change,
+            self.time_death,
+            self.death_chance,
+            self.dirt_chance,
+            self.water_needed,
+            self.underwater_needed,
+            self.land_needed,
+            self.enter_water_chance,
+            self.enter_tank_chance,
+            self.enter_land_chance,
+            self.drink_water_chance,
+            self.chase_animal_chance,
+            self.climbs_cliffs,
+            self.bash_strength,
+            self.attractiveness,
+            self.keeper_food_type,
+            self.is_climber,
+            self.is_jumper,
+            self.small_zoodoo,
+            self.dino_zoodoo,
+            self.giant_zoodoo,
+            self.is_special_animal,
+            self.need_shelter,
+            self.need_toys,
+            self.babies_attack
+        )
     }
 }
+
+impl Deref for ZTAnimalType {
+    type Target = BFEntityType;
+
+    fn deref(&self) -> &Self::Target {
+        &self.bfentitytype
+    }
+}
+
 // ------------ Custom Command Implementation ------------ //
 
 fn command_sel_type(args: Vec<&str>) -> Result<String, &'static str> {
@@ -2147,7 +2310,7 @@ fn print_config_for_type() -> String {
         config.push_str(&rubble_type.print_config_integers());
 
         print_info_image_name(entity_type, &mut config);
-    } else if class_type == "Animal" || class_type == "Keeper" || class_type == "MaintenanceWorker" || class_type == "TourGuide" || class_type == "DRT" {
+    } else if class_type == "Keeper" || class_type == "MaintenanceWorker" || class_type == "TourGuide" || class_type == "DRT" {
         info!("Entity type is a ZTUnit. Printing ZTUnit type configuration.");
         let ztunit_type = ZTUnitType::new(entity_type_address).unwrap(); // create a copied instance of the entity type
         config.push_str(&ztunit_type.bfunit_type.bfentitytype.print_config_integers());
@@ -2165,10 +2328,15 @@ fn print_config_for_type() -> String {
         config.push_str(&ztguest_type.print_config_integers());
 
         // print_info_image_name(entity_type, &mut config);
+    } else if class_type == "Animal" {
+        info!("Entity type is a ZTAnimal. Printing ZTAnimal type configuration.");
+        let ztanimal_type = ZTAnimalType::new(entity_type_address).unwrap(); // create a copied instance of the entity type
+        config.push_str(&ztanimal_type.bfentitytype.print_config_integers());
+        config.push_str(&ztanimal_type.print_config_integers());
+
+        // print_info_image_name(entity_type, &mut config);
     } else {
-        info!(
-            "Entity type is not a known entity type. Printing base entity type configuration only."
-        );
+        info!("Entity type is not a known type. Skipping additional configuration.");
     }
 
     // print [colorrep] section of the configuration - available in all entity types
@@ -2218,6 +2386,9 @@ fn parse_subargs_for_type(_args: Vec<&str>) -> Result<String, &'static str> {
     let result_ztguest_type = ZTGuestType::new(entity_type_address)
         .unwrap()
         .set_config(_args[0], _args[1]);
+    let result_ztanimal_type = ZTAnimalType::new(entity_type_address)
+        .unwrap()
+        .set_config(_args[0], _args[1]);
 
     // return the result of the first successful configuration change
     if result_entity_type.is_ok() {
@@ -2244,6 +2415,8 @@ fn parse_subargs_for_type(_args: Vec<&str>) -> Result<String, &'static str> {
         result_ztunit_type
     } else if result_ztguest_type.is_ok() {
         result_ztguest_type
+    } else if result_ztanimal_type.is_ok() {
+        result_ztanimal_type
     } else {
         Err("Invalid configuration option")
     }

--- a/src/bfentitytype.rs
+++ b/src/bfentitytype.rs
@@ -1676,111 +1676,112 @@ impl Deref for ZTGuestType {
 struct ZTAnimalType {
     pub ztunit_type: ZTUnitType, // bytes: 0x188 - 0x100 = 0x88 = 136 bytes
     pad00: [u8; 0x1D8 - 0x188], // ----------------------- padding: 72 bytes
-    box_footprint_x: i32, // 0x1D8
-    box_footprint_y: i32, // 0x1DC
-    box_footprint_z: i32, // 0x1E0
-    family: i32, // 0x1E4
-    genus: i32, // 0x1E8
+    pub box_footprint_x: i32, // 0x1D8
+    pub box_footprint_y: i32, // 0x1DC
+    pub box_footprint_z: i32, // 0x1E0
+    pub family: i32, // 0x1E4
+    pub genus: i32, // 0x1E8
     pad01: [u8; 0x1F0 - 0x1EC], // ----------------------- padding: 4 bytes
-    habitat: i32, // 0x1F0
-    location: i32, // 0x1F4
-    era: i32, // 0x1F8
-    breath_threshold: i32, // 0x1FC
-    breath_increment: i32, // 0x200
+    pub habitat: i32, // 0x1F0
+    pub location: i32, // 0x1F4
+    pub era: i32, // 0x1F8
+    pub breath_threshold: i32, // 0x1FC
+    pub breath_increment: i32, // 0x200
     pad02: [u8; 0x20C - 0x204], // ----------------------- padding: 8 bytes
-    hunger_threshold: i32, // 0x20C
-    hungry_health_change: i32, // 0x210
-    hunger_increment: i32, // 0x214
-    food_unit_value: i32, // 0x218
-    keeper_food_units_eaten: i32, // 0x21C
-    needed_food: i32, // 0x220
-    no_food_change: i32, // 0x224
-    initial_happiness: i32, // 0x228
+    pub hunger_threshold: i32, // 0x20C
+    pub hungry_health_change: i32, // 0x210
+    pub hunger_increment: i32, // 0x214
+    pub food_unit_value: i32, // 0x218
+    pub keeper_food_units_eaten: i32, // 0x21C
+    pub needed_food: i32, // 0x220
+    pub no_food_change: i32, // 0x224
+    pub initial_happiness: i32, // 0x228
     pad04: [u8; 0x234 - 0x22C], // ----------------------- padding: 12 bytes
-    max_hits: i32, // 0x234
-    pad05: [u8; 0x23C - 0x238], // ----------------------- padding: 4 bytes
-    pct_hits: i32, // 0x23C
-    pad06: [u8; 0x248 - 0x240], // ----------------------- padding: 8 bytes
-    max_energy: i32, // 0x248
+    pub max_hits: i32, // 0x234
+    pad004: [u8; 0x23C - 0x238], // ----------------------- padding: 4 bytes
+    pub pct_hits: i32, // 0x23C
+    pad05: [u8; 0x248 - 0x240], // ----------------------- padding: 8 bytes
+    pub max_energy: i32, // 0x248
     pad07: [u8; 0x250 - 0x24C], // ----------------------- padding: 4 bytes
-    max_dirty: i32, // 0x250
-    min_dirty: i32, // 0x254
-    sick_change: i32, // 0x258
-    other_animal_sick_change: i32, // 0x25C
-    sick_chance: i32, // 0x260
-    sick_random_chance: i32, // 0x264
-    crowd: i32, // 0x268
-    crowd_happiness_change: i32, // 0x26C
-    zap_happiness_change: i32, // 0x270
-    captivity: i32, // 0x274
-    reproduction_chance: i32, // 0x278
-    reproduction_interval: i32, // 0x27C
-    mating_type: i32, // 0x280
-    offspring: i32, // 0x284
-    keeper_frequency: i32, // 0x288
-    pad007: [u8; 0x290 - 0x28C], // ----------------------- padding: 4 bytes
-    not_enough_keepers_change: i32, // 0x290
-    social: i32, // 0x294
-    habitat_size: i32, // 0x298
-    number_animals_min: i32, // 0x29C
-    number_animals_max: i32, // 0x2A0
-    pad08: [u8; 0x2AC - 0x2A4], // ----------------------- padding: 8 bytes
-    number_min_change: i32, // 0x2AC
-    number_max_change: i32, // 0x2B0
-    pad09: [u8; 0x2BC - 0x2B4], // ----------------------- padding: 8 bytes
-    habitat_preference: i32, // 0x2BC
-    pad10: [u8; 0x31C - 0x2C0], // ----------------------- padding: 92 bytes
-    baby_born_change: i32, // 0x31C
-    pad11: [u8; 0x320 - 0x320], // ----------------------- padding: 4 bytes
-    energy_increment: i32, // 0x320
-    energy_threshold: i32, // 0x324
-    dirty_increment: i32, // 0x328
-    dirty_threshold: i32, // 0x32C
-    pad12: [u8; 0x330 - 0x330], // ----------------------- padding: 4 bytes
-    sick_time: i32, // 0x330
-    pad13: [u8; 0x344 - 0x334], // ----------------------- padding: 16 bytes
-    baby_to_adult: i32, // 0x344
-    pad14: [u8; 0x348 - 0x348], // ----------------------- padding: 4 bytes
-    other_food: i32, // 0x348
-    tree_pref: i32, // 0x34C
-    rock_pref: i32, // 0x350
-    space_pref: i32, // 0x354
-    elevation_pref: i32, // 0x358
-    depth_min: i32, // 0x35C
-    depth_max: i32, // 0x360
-    depth_change: i32, // 0x364
-    salinity_change: i32, // 0x368
-    salinity_health_change: i32, // 0x36C
-    pad15: [u8; 0x378 - 0x370], // ----------------------- padding: 8 bytes
-    happy_reproduce_threshold: i32, // 0x378
-    pad16: [u8; 0x37C - 0x37C], // ----------------------- padding: 4 bytes
-    building_use_chance: i32, // 0x37C
-    no_mate_change: i32, // 0x380
-    time_death: i32, // 0x384
-    death_chance: i32, // 0x388
-    dirt_chance: i32, // 0x38C
-    water_needed: i32, // 0x390
-    underwater_needed: i32, // 0x394
-    land_needed: i32, // 0x398
-    enter_water_chance: i32, // 0x39C
-    enter_tank_chance: i32, // 0x3A0
-    enter_land_chance: i32, // 0x3A4
-    drink_water_chance: i32, // 0x3A8
-    chase_animal_chance: i32, // 0x3AC
-    climbs_cliffs: i32, // 0x3B0
-    bash_strength: i32, // 0x3B4
-    attractiveness: i32, // 0x3B8
-    pad17: [u8; 0x3C8 - 0x3BC], // ----------------------- padding: 8 bytes
-    keeper_food_type: i32, // 0x3C8
-    is_climber: bool, // 0x3CC
-    is_jumper: bool, // 0x3CD
-    small_zoodoo: bool, // 0x3CE
-    dino_zoodoo: bool, // 0x3CF
-    giant_zoodoo: bool, // 0x3D0
-    is_special_animal: bool, // 0x3D1
-    need_shelter: bool, // 0x3D2
-    need_toys: bool, // 0x3D3
-    babies_attack: bool, // 0x3D4
+    pub max_dirty: i32, // 0x250
+    pub min_dirty: i32, // 0x254
+    pub sick_change: i32, // 0x258
+    pub other_animal_sick_change: i32, // 0x25C
+    pub sick_chance: i32, // 0x260
+    pub sick_random_chance: i32, // 0x264
+    pub crowd: i32, // 0x268
+    pub crowd_happiness_change: i32, // 0x26C
+    pub zap_happiness_change: i32, // 0x270
+    pub captivity: i32, // 0x274
+    pub reproduction_chance: i32, // 0x278
+    pub reproduction_interval: i32, // 0x27C
+    pub mating_type: i32, // 0x280
+    pub offspring: i32, // 0x284
+    pub keeper_frequency: i32, // 0x288
+    pad08: [u8; 0x290 - 0x28C], // ----------------------- padding: 4 bytes
+    pub not_enough_keepers_change: i32, // 0x290
+    pub social: i32, // 0x294
+    pub habitat_size: i32, // 0x298
+    pub number_animals_min: i32, // 0x29C
+    pub number_animals_max: i32, // 0x2A0
+    pad09: [u8; 0x2AC - 0x2A4], // ----------------------- padding: 8 bytes
+    pub number_min_change: i32, // 0x2AC
+    pub number_max_change: i32, // 0x2B0
+    pad10: [u8; 0x2BC - 0x2B4], // ----------------------- padding: 8 bytes
+    pub habitat_preference: i32, // 0x2BC
+    pad11: [u8; 0x31C - 0x2C0], // ----------------------- padding: 92 bytes
+    pub baby_born_change: i32, // 0x31C
+    pad12: [u8; 0x320 - 0x320], // ----------------------- padding: 4 bytes
+    pub energy_increment: i32, // 0x320
+    pub energy_threshold: i32, // 0x324
+    pub dirty_increment: i32, // 0x328
+    pub dirty_threshold: i32, // 0x32C
+    pad13: [u8; 0x330 - 0x330], // ----------------------- padding: 4 bytes
+    pub sick_time: i32, // 0x330
+    pad14: [u8; 0x344 - 0x334], // ----------------------- padding: 16 bytes
+    pub baby_to_adult: i32, // 0x344
+    pad15: [u8; 0x348 - 0x348], // ----------------------- padding: 4 bytes
+    pub other_food: i32, // 0x348
+    pub tree_pref: i32, // 0x34C
+    pub rock_pref: i32, // 0x350
+    pub space_pref: i32, // 0x354
+    pub elevation_pref: i32, // 0x358
+    pub depth_min: i32, // 0x35C
+    pub depth_max: i32, // 0x360
+    pub depth_change: i32, // 0x364
+    pub salinity_change: i32, // 0x368
+    pub salinity_health_change: i32, // 0x36C
+    pad16: [u8; 0x378 - 0x370], // ----------------------- padding: 8 bytes
+    pub happy_reproduce_threshold: i32, // 0x378
+    pad17: [u8; 0x37C - 0x37C], // ----------------------- padding: 4 bytes
+    pub building_use_chance: i32, // 0x37C
+    pub no_mate_change: i32, // 0x380
+    pub time_death: i32, // 0x384
+    pub death_chance: i32, // 0x388
+    pub dirt_chance: i32, // 0x38C
+    pub water_needed: i32, // 0x390
+    pub underwater_needed: i32, // 0x394
+    pub land_needed: i32, // 0x398
+    pub enter_water_chance: i32, // 0x39C
+    pub enter_tank_chance: i32, // 0x3A0
+    pub enter_land_chance: i32, // 0x3A4
+    pub drink_water_chance: i32, // 0x3A8
+    pub chase_animal_chance: i32, // 0x3AC
+    pub climbs_cliffs: i32, // 0x3B0
+    pub bash_strength: i32, // 0x3B4
+    pub attractiveness: i32, // 0x3B8
+    pad18: [u8; 0x3C8 - 0x3BC], // ----------------------- padding: 8 bytes
+    pub keeper_food_type: i32, // 0x3C8
+    pub is_climber: bool, // 0x3CC
+    pub is_jumper: bool, // 0x3CD
+    pub small_zoodoo: bool, // 0x3CE
+    pub dino_zoodoo: bool, // 0x3CF
+    pub giant_zoodoo: bool, // 0x3D0
+    pub is_special_animal: bool, // 0x3D1
+    pub need_shelter: bool, // 0x3D2
+    pub need_toys: bool, // 0x3D3
+    pub babies_attack: bool, // 0x3D4
+
 }
 
 impl ZTAnimalType {
@@ -2040,13 +2041,13 @@ impl ZTAnimalType {
             self.is_jumper = value.parse::<bool>().unwrap();
             Ok(format!("Set Is Jumper to {}", self.is_jumper))
         } else if config == "-cSmallZoodoo" {
-            self.small_zoodoo = value.parse::<i32>().unwrap();
+            self.small_zoodoo = value.parse::<bool>().unwrap();
             Ok(format!("Set Small Zoodoo to {}", self.small_zoodoo))
         } else if config == "-cDinoZoodoo" {
-            self.dino_zoodoo = value.parse::<i32>().unwrap();
+            self.dino_zoodoo = value.parse::<bool>().unwrap();
             Ok(format!("Set Dino Zoodoo to {}", self.dino_zoodoo))
         } else if config == "-cGiantZoodoo" {
-            self.giant_zoodoo = value.parse::<i32>().unwrap();
+            self.giant_zoodoo = value.parse::<bool>().unwrap();
             Ok(format!("Set Giant Zoodoo to {}", self.giant_zoodoo))
         } else if config == "-cIsSpecialAnimal" {
             self.is_special_animal = value.parse::<bool>().unwrap();
@@ -2066,9 +2067,7 @@ impl ZTAnimalType {
     }
 
     pub fn print_config_integers(&self) -> String {
-    format!(
-        "Box Footprint X: {}\nBox Footprint Y: {}\nBox Footprint Z: {}\nFamily: {}\nGenus: {}\nHabitat: {}\nLocation: {}\nEra: {}\nBreath Threshold: {}\nBreath Increment: {}\nHunger Threshold: {}\nHungry Health Change: {}\nHunger Increment: {}\nFood Unit Value: {}\nKeeper Food Units Eaten: {}\nNeeded Food: {}\nNo Food Change: {}\nInitial Happiness: {}\nMax Hits: {}\nPct Hits: {}\nMax Energy: {}\nMax Dirty: {}\nMin Dirty: {}\nSick Change: {}\nOther Animal Sick Change: {}\nSick Chance: {}\nSick Random Chance: {}\nCrowd: {}\nCrowd Happiness Change: {}\nZap Happiness Change: {}\nCaptivity: {}\nReproduction Chance: {}\nReproduction Interval: {}\nMating Type: {}\nOffspring: {}\nKeeper Frequency: {}\nNot Enough Keepers Change: {}\nSocial: {}\nHabitat Size: {}\nNumber Animals Min: {}\nNumber Animals Max: {}\nNumber Min Change: {}\nNumber Max Change: {}\nHabitat Preference: {}\nBaby Born Change: {}\nEnergy Increment: {}\nEnergy Threshold: {}\nDirty Increment: {}\nDirty Threshold: {}\nSick Time: {}\nBaby To Adult: {}\nOther Food: {}\nTree Pref: {}\nRock Pref: {}\nSpace Pref: {}\nElevation Pref: {}\nDepth Min: {}\nDepth Max: {}\nDepth Change: {}\nSalinity Change: {}\nSalinity Health Change: {}\nHappy Reproduce Threshold: {}\nBuilding Use Chance: {}\nNo Mate Change: {}\nTime Death: {}\nDeath Chance: {}\nDirt Chance: {}\nWater Needed: {}\nUnderwater Needed: {}\nLand Needed: {}\nEnter Water Chance: {}\nEnter Tank Chance: {}\nEnter Land Chance: {}\nDrink Water Chance: {}\nChase Animal Chance: {}\nClimbs Cliffs: {}\nBash Strength: {}\nAttractiveness: {}\nKeeper Food Type: {}\nIs Climber: {}\nIs Jumper: {}\nSmall Zoodoo: {}\nDino Zoodoo: {}\nGiant Zoodoo: {}\nIs Special Animal: {}\
-        Need Shelter: {}\nNeed Toys: {}\nBabies Attack: {}\n",
+    format!("cBoxFootprintX: {}\ncBoxFootprintY: {}\ncBoxFootprintZ: {}\ncFamily: {}\ncGenus: {}\ncHabitat: {}\ncLocation: {}\ncEra: {}\ncBreathThreshold: {}\ncBreathIncrement: {}\ncHungerThreshold: {}\ncHungryHealthChange: {}\ncHungerIncrement: {}\ncFoodUnitValue: {}\ncKeeperFoodUnitsEaten: {}\ncNeededFood: {}\ncNoFoodChange: {}\ncInitialHappiness: {}\ncMaxHits: {}\ncPctHits: {}\ncMaxEnergy: {}\ncMaxDirty: {}\ncMinDirty: {}\ncSickChange: {}\ncOtherAnimalSickChange: {}\ncSickChance: {}\ncSickRandomChance: {}\ncCrowd: {}\ncCrowdHappinessChange: {}\ncZapHappinessChange: {}\ncCaptivity: {}\ncReproductionChance: {}\ncReproductionInterval: {}\ncMatingType: {}\ncOffspring: {}\ncKeeperFrequency: {}\ncNotEnoughKeepersChange: {}\ncSocial: {}\ncHabitatSize: {}\ncNumberAnimalsMin: {}\ncNumberAnimalsMax: {}\ncNumberMinChange: {}\ncNumberMaxChange: {}\ncHabitatPreference: {}\ncBabyBornChange: {}\ncEnergyIncrement: {}\ncEnergyThreshold: {}\ncDirtyIncrement: {}\ncDirtyThreshold: {}\ncSickTime: {}\ncBabyToAdult: {}\ncOtherFood: {}\ncTreePref: {}\ncRockPref: {}\ncSpacePref: {}\ncElevationPref: {}\ncDepthMin: {}\ncDepthMax: {}\ncDepthChange: {}\ncSalinityChange: {}\ncSalinityHealthChange: {}\ncHappyReproduceThreshold: {}\ncBuildingUseChance: {}\ncNoMateChange: {}\ncTimeDeath: {}\ncDeathChance: {}\ncDirtChance: {}\ncWaterNeeded: {}\ncUnderwaterNeeded: {}\ncLandNeeded: {}\ncEnterWaterChance: {}\ncEnterTankChance: {}\ncEnterLandChance: {}\ncDrinkWaterChance: {}\ncChaseAnimalChance: {}\ncClimbsCliffs: {}\ncBashStrength: {}\ncAttractiveness: {}\ncKeeperFoodType: {}\ncIsClimber: {}\ncIsJumper: {}\ncSmallZoodoo: {}\ncDinoZoodoo: {}\ncGiantZoodoo: {}\ncIsSpecialAnimal: {}\ncNeedShelter: {}\ncNeedToys: {}\ncBabiesAttack: {}\n",
         self.box_footprint_x,
         self.box_footprint_y,
         self.box_footprint_z,
@@ -2136,9 +2135,9 @@ impl ZTAnimalType {
         self.time_death,
         self.death_chance,
         self.dirt_chance,
-        self.water_needed,
-        self.underwater_needed,
-        self.land_needed,
+        self.water_needed as i32,
+        self.underwater_needed as i32,
+        self.land_needed as i32,
         self.enter_water_chance,
         self.enter_tank_chance,
         self.enter_land_chance,
@@ -2148,15 +2147,15 @@ impl ZTAnimalType {
         self.bash_strength,
         self.attractiveness,
         self.keeper_food_type,
-        self.is_climber,
-        self.is_jumper,
-        self.small_zoodoo,
-        self.dino_zoodoo,
-        self.giant_zoodoo,
-        self.is_special_animal,
-        self.need_shelter,
-        self.need_toys,
-        self.babies_attack
+        self.is_climber as i32,
+        self.is_jumper as i32,
+        self.small_zoodoo as i32,
+        self.dino_zoodoo as i32,
+        self.giant_zoodoo as i32,
+        self.is_special_animal as i32,
+        self.need_shelter as i32,
+        self.need_toys as i32,
+        self.babies_attack as i32,
         )
     }
 }

--- a/src/bfentitytype.rs
+++ b/src/bfentitytype.rs
@@ -1675,7 +1675,7 @@ impl Deref for ZTGuestType {
 #[repr(C)]
 struct ZTAnimalType {
     pub ztunit_type: ZTUnitType, // bytes: 0x188 - 0x100 = 0x88 = 136 bytes
-    pad00: [u8; 0x1B4 - 0x188], // ----------------------- padding: 44 bytes
+    pad00: [u8; 0x1D8 - 0x188], // ----------------------- padding: 72 bytes
     box_footprint_x: i32, // 0x1D8
     box_footprint_y: i32, // 0x1DC
     box_footprint_z: i32, // 0x1E0
@@ -1695,7 +1695,6 @@ struct ZTAnimalType {
     keeper_food_units_eaten: i32, // 0x21C
     needed_food: i32, // 0x220
     no_food_change: i32, // 0x224
-    pad03: [u8; 0x234 - 0x228], // ----------------------- padding: 12 bytes
     initial_happiness: i32, // 0x228
     pad04: [u8; 0x234 - 0x22C], // ----------------------- padding: 12 bytes
     max_hits: i32, // 0x234
@@ -1719,6 +1718,7 @@ struct ZTAnimalType {
     mating_type: i32, // 0x280
     offspring: i32, // 0x284
     keeper_frequency: i32, // 0x288
+    pad007: [u8; 0x290 - 0x28C], // ----------------------- padding: 4 bytes
     not_enough_keepers_change: i32, // 0x290
     social: i32, // 0x294
     habitat_size: i32, // 0x298
@@ -1774,9 +1774,9 @@ struct ZTAnimalType {
     keeper_food_type: i32, // 0x3C8
     is_climber: bool, // 0x3CC
     is_jumper: bool, // 0x3CD
-    small_zoodoo: i32, // 0x3CE
-    dino_zoodoo: i32, // 0x3CF
-    giant_zoodoo: i32, // 0x3D0
+    small_zoodoo: bool, // 0x3CE
+    dino_zoodoo: bool, // 0x3CF
+    giant_zoodoo: bool, // 0x3D0
     is_special_animal: bool, // 0x3D1
     need_shelter: bool, // 0x3D2
     need_toys: bool, // 0x3D3

--- a/src/bfentitytype.rs
+++ b/src/bfentitytype.rs
@@ -1674,8 +1674,8 @@ impl Deref for ZTGuestType {
 #[derive(Debug, Getters, Setters)]
 #[repr(C)]
 struct ZTAnimalType {
-    ztunit_type: ZTUnitType, // bytes: 0x1D8 - 0x100 = 0xD8 = 216 bytes
-    pad00: [u8; 0x1D8 - 0x100], // ----------------------- padding: 216 bytes
+    pub ztunit_type: ZTUnitType, // bytes: 0x188 - 0x100 = 0x88 = 136 bytes
+    pad00: [u8; 0x1B4 - 0x188], // ----------------------- padding: 44 bytes
     box_footprint_x: i32, // 0x1D8
     box_footprint_y: i32, // 0x1DC
     box_footprint_z: i32, // 0x1E0
@@ -2063,108 +2063,109 @@ impl ZTAnimalType {
         } else {
             Err("Invalid configuration option")
         }
+    }
 
-        pub fn print_config_integers(&self) -> String {
-        format!(
-            "Box Footprint X: {}\nBox Footprint Y: {}\nBox Footprint Z: {}\nFamily: {}\nGenus: {}\nHabitat: {}\nLocation: {}\nEra: {}\nBreath Threshold: {}\nBreath Increment: {}\nHunger Threshold: {}\nHungry Health Change: {}\nHunger Increment: {}\nFood Unit Value: {}\nKeeper Food Units Eaten: {}\nNeeded Food: {}\nNo Food Change: {}\nInitial Happiness: {}\nMax Hits: {}\nPct Hits: {}\nMax Energy: {}\nMax Dirty: {}\nMin Dirty: {}\nSick Change: {}\nOther Animal Sick Change: {}\nSick Chance: {}\nSick Random Chance: {}\nCrowd: {}\nCrowd Happiness Change: {}\nZap Happiness Change: {}\nCaptivity: {}\nReproduction Chance: {}\nReproduction Interval: {}\nMating Type: {}\nOffspring: {}\nKeeper Frequency: {}\nNot Enough Keepers Change: {}\nSocial: {}\nHabitat Size: {}\nNumber Animals Min: {}\nNumber Animals Max: {}\nNumber Min Change: {}\nNumber Max Change: {}\nHabitat Preference: {}\nBaby Born Change: {}\nEnergy Increment: {}\nEnergy Threshold: {}\nDirty Increment: {}\nDirty Threshold: {}\nSick Time: {}\nBaby To Adult: {}\nOther Food: {}\nTree Pref: {}\nRock Pref: {}\nSpace Pref: {}\nElevation Pref: {}\nDepth Min: {}\nDepth Max: {}\nDepth Change: {}\nSalinity Change: {}\nSalinity Health Change: {}\nHappy Reproduce Threshold: {}\nBuilding Use Chance: {}\nNo Mate Change: {}\nTime Death: {}\nDeath Chance: {}\nDirt Chance: {}\nWater Needed: {}\nUnderwater Needed: {}\nLand Needed: {}\nEnter Water Chance: {}\nEnter Tank Chance: {}\nEnter Land Chance: {}\nDrink Water Chance: {}\nChase Animal Chance: {}\nClimbs Cliffs: {}\nBash Strength: {}\nAttractiveness: {}\nKeeper Food Type: {}\nIs Climber: {}\nIs Jumper: {}\nSmall Zoodoo: {}\nDino Zoodoo: {}\nGiant Zoodoo: {}\nIs Special Animal: {}\
-            Need Shelter: {}\nNeed Toys: {}\nBabies Attack: {}\n",
-            self.box_footprint_x,
-            self.box_footprint_y,
-            self.box_footprint_z,
-            self.family,
-            self.genus,
-            self.habitat,
-            self.location,
-            self.era,
-            self.breath_threshold,
-            self.breath_increment,
-            self.hunger_threshold,
-            self.hungry_health_change,
-            self.hunger_increment,
-            self.food_unit_value,
-            self.keeper_food_units_eaten,
-            self.needed_food,
-            self.no_food_change,
-            self.initial_happiness,
-            self.max_hits,
-            self.pct_hits,
-            self.max_energy,
-            self.max_dirty,
-            self.min_dirty,
-            self.sick_change,
-            self.other_animal_sick_change,
-            self.sick_chance,
-            self.sick_random_chance,
-            self.crowd,
-            self.crowd_happiness_change,
-            self.zap_happiness_change,
-            self.captivity,
-            self.reproduction_chance,
-            self.reproduction_interval,
-            self.mating_type,
-            self.offspring,
-            self.keeper_frequency,
-            self.not_enough_keepers_change,
-            self.social,
-            self.habitat_size,
-            self.number_animals_min,
-            self.number_animals_max,
-            self.number_min_change,
-            self.number_max_change,
-            self.habitat_preference,
-            self.baby_born_change,
-            self.energy_increment,
-            self.energy_threshold,
-            self.dirty_increment,
-            self.dirty_threshold,
-            self.sick_time,
-            self.baby_to_adult,
-            self.other_food,
-            self.tree_pref,
-            self.rock_pref,
-            self.space_pref,
-            self.elevation_pref,
-            self.depth_min,
-            self.depth_max,
-            self.depth_change,
-            self.salinity_change,
-            self.salinity_health_change,
-            self.happy_reproduce_threshold,
-            self.building_use_chance,
-            self.no_mate_change,
-            self.time_death,
-            self.death_chance,
-            self.dirt_chance,
-            self.water_needed,
-            self.underwater_needed,
-            self.land_needed,
-            self.enter_water_chance,
-            self.enter_tank_chance,
-            self.enter_land_chance,
-            self.drink_water_chance,
-            self.chase_animal_chance,
-            self.climbs_cliffs,
-            self.bash_strength,
-            self.attractiveness,
-            self.keeper_food_type,
-            self.is_climber,
-            self.is_jumper,
-            self.small_zoodoo,
-            self.dino_zoodoo,
-            self.giant_zoodoo,
-            self.is_special_animal,
-            self.need_shelter,
-            self.need_toys,
-            self.babies_attack
+    pub fn print_config_integers(&self) -> String {
+    format!(
+        "Box Footprint X: {}\nBox Footprint Y: {}\nBox Footprint Z: {}\nFamily: {}\nGenus: {}\nHabitat: {}\nLocation: {}\nEra: {}\nBreath Threshold: {}\nBreath Increment: {}\nHunger Threshold: {}\nHungry Health Change: {}\nHunger Increment: {}\nFood Unit Value: {}\nKeeper Food Units Eaten: {}\nNeeded Food: {}\nNo Food Change: {}\nInitial Happiness: {}\nMax Hits: {}\nPct Hits: {}\nMax Energy: {}\nMax Dirty: {}\nMin Dirty: {}\nSick Change: {}\nOther Animal Sick Change: {}\nSick Chance: {}\nSick Random Chance: {}\nCrowd: {}\nCrowd Happiness Change: {}\nZap Happiness Change: {}\nCaptivity: {}\nReproduction Chance: {}\nReproduction Interval: {}\nMating Type: {}\nOffspring: {}\nKeeper Frequency: {}\nNot Enough Keepers Change: {}\nSocial: {}\nHabitat Size: {}\nNumber Animals Min: {}\nNumber Animals Max: {}\nNumber Min Change: {}\nNumber Max Change: {}\nHabitat Preference: {}\nBaby Born Change: {}\nEnergy Increment: {}\nEnergy Threshold: {}\nDirty Increment: {}\nDirty Threshold: {}\nSick Time: {}\nBaby To Adult: {}\nOther Food: {}\nTree Pref: {}\nRock Pref: {}\nSpace Pref: {}\nElevation Pref: {}\nDepth Min: {}\nDepth Max: {}\nDepth Change: {}\nSalinity Change: {}\nSalinity Health Change: {}\nHappy Reproduce Threshold: {}\nBuilding Use Chance: {}\nNo Mate Change: {}\nTime Death: {}\nDeath Chance: {}\nDirt Chance: {}\nWater Needed: {}\nUnderwater Needed: {}\nLand Needed: {}\nEnter Water Chance: {}\nEnter Tank Chance: {}\nEnter Land Chance: {}\nDrink Water Chance: {}\nChase Animal Chance: {}\nClimbs Cliffs: {}\nBash Strength: {}\nAttractiveness: {}\nKeeper Food Type: {}\nIs Climber: {}\nIs Jumper: {}\nSmall Zoodoo: {}\nDino Zoodoo: {}\nGiant Zoodoo: {}\nIs Special Animal: {}\
+        Need Shelter: {}\nNeed Toys: {}\nBabies Attack: {}\n",
+        self.box_footprint_x,
+        self.box_footprint_y,
+        self.box_footprint_z,
+        self.family,
+        self.genus,
+        self.habitat,
+        self.location,
+        self.era,
+        self.breath_threshold,
+        self.breath_increment,
+        self.hunger_threshold,
+        self.hungry_health_change,
+        self.hunger_increment,
+        self.food_unit_value,
+        self.keeper_food_units_eaten,
+        self.needed_food,
+        self.no_food_change,
+        self.initial_happiness,
+        self.max_hits,
+        self.pct_hits,
+        self.max_energy,
+        self.max_dirty,
+        self.min_dirty,
+        self.sick_change,
+        self.other_animal_sick_change,
+        self.sick_chance,
+        self.sick_random_chance,
+        self.crowd,
+        self.crowd_happiness_change,
+        self.zap_happiness_change,
+        self.captivity,
+        self.reproduction_chance,
+        self.reproduction_interval,
+        self.mating_type,
+        self.offspring,
+        self.keeper_frequency,
+        self.not_enough_keepers_change,
+        self.social,
+        self.habitat_size,
+        self.number_animals_min,
+        self.number_animals_max,
+        self.number_min_change,
+        self.number_max_change,
+        self.habitat_preference,
+        self.baby_born_change,
+        self.energy_increment,
+        self.energy_threshold,
+        self.dirty_increment,
+        self.dirty_threshold,
+        self.sick_time,
+        self.baby_to_adult,
+        self.other_food,
+        self.tree_pref,
+        self.rock_pref,
+        self.space_pref,
+        self.elevation_pref,
+        self.depth_min,
+        self.depth_max,
+        self.depth_change,
+        self.salinity_change,
+        self.salinity_health_change,
+        self.happy_reproduce_threshold,
+        self.building_use_chance,
+        self.no_mate_change,
+        self.time_death,
+        self.death_chance,
+        self.dirt_chance,
+        self.water_needed,
+        self.underwater_needed,
+        self.land_needed,
+        self.enter_water_chance,
+        self.enter_tank_chance,
+        self.enter_land_chance,
+        self.drink_water_chance,
+        self.chase_animal_chance,
+        self.climbs_cliffs,
+        self.bash_strength,
+        self.attractiveness,
+        self.keeper_food_type,
+        self.is_climber,
+        self.is_jumper,
+        self.small_zoodoo,
+        self.dino_zoodoo,
+        self.giant_zoodoo,
+        self.is_special_animal,
+        self.need_shelter,
+        self.need_toys,
+        self.babies_attack
         )
     }
 }
 
 impl Deref for ZTAnimalType {
-    type Target = BFEntityType;
+    type Target = ZTUnitType;
 
     fn deref(&self) -> &Self::Target {
-        &self.bfentitytype
+        &self.ztunit_type
     }
 }
 
@@ -2331,7 +2332,9 @@ fn print_config_for_type() -> String {
     } else if class_type == "Animal" {
         info!("Entity type is a ZTAnimal. Printing ZTAnimal type configuration.");
         let ztanimal_type = ZTAnimalType::new(entity_type_address).unwrap(); // create a copied instance of the entity type
-        config.push_str(&ztanimal_type.bfentitytype.print_config_integers());
+        config.push_str(&ztanimal_type.ztunit_type.bfunit_type.bfentitytype.print_config_integers());
+        config.push_str(&ztanimal_type.ztunit_type.bfunit_type.print_config_integers());
+        config.push_str(&ztanimal_type.ztunit_type.print_config_integers());
         config.push_str(&ztanimal_type.print_config_integers());
 
         // print_info_image_name(entity_type, &mut config);

--- a/src/bfentitytype.rs
+++ b/src/bfentitytype.rs
@@ -1669,6 +1669,342 @@ impl Deref for ZTGuestType {
     }
 }
 
+// ------------ ZTAnimalType, Implementation, and Related Functions ------------ //
+
+#[derive(Debug, Getters, Setters)]
+#[repr(C)]
+struct ZTAnimalType {
+    ztunit_type: ZTUnitType, // bytes: 0x1D8 - 0x100 = 0xD8 = 216 bytes
+    pad00: [u8; 0x1D8 - 0x100], // ----------------------- padding: 216 bytes
+    box_footprint_x: i32, // 0x1D8
+    box_footprint_y: i32, // 0x1DC
+    box_footprint_z: i32, // 0x1E0
+    family: i32, // 0x1E4
+    genus: i32, // 0x1E8
+    pad01: [u8; 0x1F0 - 0x1EC], // ----------------------- padding: 4 bytes
+    habitat: i32, // 0x1F0
+    location: i32, // 0x1F4
+    era: i32, // 0x1F8
+    breath_threshold: i32, // 0x1FC
+    breath_increment: i32, // 0x200
+    pad02: [u8; 0x20C - 0x204], // ----------------------- padding: 8 bytes
+    hunger_threshold: i32, // 0x20C
+    hungry_health_change: i32, // 0x210
+    hunger_increment: i32, // 0x214
+    food_unit_value: i32, // 0x218
+    keeper_food_units_eaten: i32, // 0x21C
+    needed_food: i32, // 0x220
+    no_food_change: i32, // 0x224
+    pad03: [u8; 0x234 - 0x228], // ----------------------- padding: 12 bytes
+    initial_happiness: i32, // 0x228
+    pad04: [u8; 0x234 - 0x22C], // ----------------------- padding: 12 bytes
+    max_hits: i32, // 0x234
+    pad05: [u8; 0x23C - 0x238], // ----------------------- padding: 4 bytes
+    pct_hits: i32, // 0x23C
+    pad06: [u8; 0x248 - 0x240], // ----------------------- padding: 8 bytes
+    max_energy: i32, // 0x248
+    pad07: [u8; 0x250 - 0x24C], // ----------------------- padding: 4 bytes
+    max_dirty: i32, // 0x250
+    min_dirty: i32, // 0x254
+    sick_change: i32, // 0x258
+    other_animal_sick_change: i32, // 0x25C
+    sick_chance: i32, // 0x260
+    sick_random_chance: i32, // 0x264
+    crowd: i32, // 0x268
+    crowd_happiness_change: i32, // 0x26C
+    zap_happiness_change: i32, // 0x270
+    captivity: i32, // 0x274
+    reproduction_chance: i32, // 0x278
+    reproduction_interval: i32, // 0x27C
+    mating_type: i32, // 0x280
+    offspring: i32, // 0x284
+    keeper_frequency: i32, // 0x288
+    not_enough_keepers_change: i32, // 0x290
+    social: i32, // 0x294
+    habitat_size: i32, // 0x298
+    number_animals_min: i32, // 0x29C
+    number_animals_max: i32, // 0x2A0
+    pad08: [u8; 0x2AC - 0x2A4], // ----------------------- padding: 8 bytes
+    number_min_change: i32, // 0x2AC
+    number_max_change: i32, // 0x2B0
+    pad09: [u8; 0x2BC - 0x2B4], // ----------------------- padding: 8 bytes
+    habitat_preference: i32, // 0x2BC
+    pad10: [u8; 0x31C - 0x2C0], // ----------------------- padding: 92 bytes
+    baby_born_change: i32, // 0x31C
+    pad11: [u8; 0x320 - 0x320], // ----------------------- padding: 4 bytes
+    energy_increment: i32, // 0x320
+    energy_threshold: i32, // 0x324
+    dirty_increment: i32, // 0x328
+    dirty_threshold: i32, // 0x32C
+    pad12: [u8; 0x330 - 0x330], // ----------------------- padding: 4 bytes
+    sick_time: i32, // 0x330
+    pad13: [u8; 0x344 - 0x334], // ----------------------- padding: 16 bytes
+    baby_to_adult: i32, // 0x344
+    pad14: [u8; 0x348 - 0x348], // ----------------------- padding: 4 bytes
+    other_food: i32, // 0x348
+    tree_pref: i32, // 0x34C
+    rock_pref: i32, // 0x350
+    space_pref: i32, // 0x354
+    elevation_pref: i32, // 0x358
+    depth_min: i32, // 0x35C
+    depth_max: i32, // 0x360
+    depth_change: i32, // 0x364
+    salinity_change: i32, // 0x368
+    salinity_health_change: i32, // 0x36C
+    pad15: [u8; 0x378 - 0x370], // ----------------------- padding: 8 bytes
+    happy_reproduce_threshold: i32, // 0x378
+    pad16: [u8; 0x37C - 0x37C], // ----------------------- padding: 4 bytes
+    building_use_chance: i32, // 0x37C
+    no_mate_change: i32, // 0x380
+    time_death: i32, // 0x384
+    death_chance: i32, // 0x388
+    dirt_chance: i32, // 0x38C
+    water_needed: i32, // 0x390
+    underwater_needed: i32, // 0x394
+    land_needed: i32, // 0x398
+    enter_water_chance: i32, // 0x39C
+    enter_tank_chance: i32, // 0x3A0
+    enter_land_chance: i32, // 0x3A4
+    drink_water_chance: i32, // 0x3A8
+    chase_animal_chance: i32, // 0x3AC
+    climbs_cliffs: i32, // 0x3B0
+    bash_strength: i32, // 0x3B4
+    attractiveness: i32, // 0x3B8
+    pad17: [u8; 0x3C8 - 0x3BC], // ----------------------- padding: 8 bytes
+    keeper_food_type: i32, // 0x3C8
+    is_climber: bool, // 0x3CC
+    is_jumper: bool, // 0x3CD
+    small_zoodoo: i32, // 0x3CE
+    dino_zoodoo: i32, // 0x3CF
+    giant_zoodoo: i32, // 0x3D0
+    is_special_animal: bool, // 0x3D1
+    need_shelter: bool, // 0x3D2
+    need_toys: bool, // 0x3D3
+    babies_attack: bool, // 0x3D4
+}
+
+impl ZTAnimalType {
+    pub fn new(address: u32) -> Option<&'static mut ZTAnimalType> {
+        unsafe {
+            let ptr = get_from_memory::<*mut ZTAnimalType>(address);
+            if !ptr.is_null() {
+                Some(&mut *ptr)
+            } else {
+                None
+            }
+        }
+    }
+
+    pub fn set_config(&mut self, config: &str, value: &str) -> Result<String, &'static str> {
+        if config == "-cBoxFootprintX" {
+            self.box_footprint_x = value.parse::<i32>().unwrap();
+            Ok(format!("Set Box Footprint X to {}", self.box_footprint_x))
+        } else if config == "-cBoxFootprintY" {
+            self.box_footprint_y = value.parse::<i32>().unwrap();
+            Ok(format!("Set Box Footprint Y to {}", self.box_footprint_y))
+        } else if config == "-cBoxFootprintZ" {
+            self.box_footprint_z = value.parse::<i32>().unwrap();
+            Ok(format!("Set Box Footprint Z to {}", self.box_footprint_z))
+        } else if config == "-cFamily" {
+            self.family = value.parse::<i32>().unwrap();
+            Ok(format!("Set Family to {}", self.family))
+        } else if config == "-cGenus" {
+            self.genus = value.parse::<i32>().unwrap();
+            Ok(format!("Set Genus to {}", self.genus))
+        } else if config == "-cHabitat" {
+            self.habitat = value.parse::<i32>().unwrap();
+            Ok(format!("Set Habitat to {}", self.habitat))
+        } else if config == "-cLocation" {
+            self.location = value.parse::<i32>().unwrap();
+            Ok(format!("Set Location to {}", self.location))
+        } else if config == "-cEra" {
+            self.era = value.parse::<i32>().unwrap();
+            Ok(format!("Set Era to {}", self.era))
+        } else if config == "-cBreathThreshold" {
+            self.breath_threshold = value.parse::<i32>().unwrap();
+            Ok(format!("Set Breath Threshold to {}", self.breath_threshold))
+        } else if config == "-cBreathIncrement" {
+            self.breath_increment = value.parse::<i32>().unwrap();
+            Ok(format!("Set Breath Increment to {}", self.breath_increment))
+        } else if config == "-cHungerThreshold" {
+            self.hunger_threshold = value.parse::<i32>().unwrap();
+            Ok(format!("Set Hunger Threshold to {}", self.hunger_threshold))
+        } else if config == "-cHungryHealthChange" {
+            self.hungry_health_change = value.parse::<i32>().unwrap();
+            Ok(format!("Set Hungry Health Change to {}", self.hungry_health_change))
+        } else if config == "-cHungerIncrement" {
+            self.hunger_increment = value.parse::<i32>().unwrap();
+            Ok(format!("Set Hunger Increment to {}", self.hunger_increment))
+        } else if config == "-cFoodUnitValue" {
+            self.food_unit_value = value.parse::<i32>().unwrap();
+            Ok(format!("Set Food Unit Value to {}", self.food_unit_value))
+        } else if config == "-cKeeperFoodUnitsEaten" {
+            self.keeper_food_units_eaten = value.parse::<i32>().unwrap();
+            Ok(format!("Set Keeper Food Units Eaten to {}", self.keeper_food_units_eaten))
+        } else if config == "-cNeededFood" {
+            self.needed_food = value.parse::<i32>().unwrap();
+            Ok(format!("Set Needed Food to {}", self.needed_food))
+        } else if config == "-cNoFoodChange" {
+            self.no_food_change = value.parse::<i32>().unwrap();
+            Ok(format!("Set No Food Change to {}", self.no_food_change))
+        } else if config == "-cInitialHappiness" {
+            self.initial_happiness = value.parse::<i32>().unwrap();
+            Ok(format!("Set Initial Happiness to {}", self.initial_happiness))
+        } else if config == "-cMaxHits" {
+            self.max_hits = value.parse::<i32>().unwrap();
+            Ok(format!("Set Max Hits to {}", self.max_hits))
+        } else if config == "-cPctHits" {
+            self.pct_hits = value.parse::<i32>().unwrap();
+            Ok(format!("Set Pct Hits to {}", self.pct_hits))
+        } else if config == "-cMaxEnergy" {
+            self.max_energy = value.parse::<i32>().unwrap();
+            Ok(format!("Set Max Energy to {}", self.max_energy))
+        } else if config == "-cMaxDirty" {
+            self.max_dirty = value.parse::<i32>().unwrap();
+            Ok(format!("Set Max Dirty to {}", self.max_dirty))
+        } else if config == "-cMinDirty" {
+            self.min_dirty = value.parse::<i32>().unwrap();
+            Ok(format!("Set Min Dirty to {}", self.min_dirty))
+        } else if config == "-cSickChange" {
+            self.sick_change = value.parse::<i32>().unwrap();
+            Ok(format!("Set Sick Change to {}", self.sick_change))
+        } else if config == "-cOtherAnimalSickChange" {
+            self.other_animal_sick_change = value.parse::<i32>().unwrap();
+            Ok(format!("Set Other Animal Sick Change to {}", self.other_animal_sick_change))
+        } else if config == "-cSickChance" {
+            self.sick_chance = value.parse::<i32>().unwrap();
+            Ok(format!("Set Sick Chance to {}", self.sick_chance))
+        } else if config == "-cSickRandomChance" {
+            self.sick_random_chance = value.parse::<i32>().unwrap();
+            Ok(format!("Set Sick Random Chance to {}", self.sick_random_chance))
+        } else if config == "-cCrowd" {
+            self.crowd = value.parse::<i32>().unwrap();
+            Ok(format!("Set Crowd to {}", self.crowd))
+        } else if config == "-cCrowdHappinessChange" {
+            self.crowd_happiness_change = value.parse::<i32>().unwrap();
+            Ok(format!("Set Crowd Happiness Change to {}", self.crowd_happiness_change))
+        } else if config == "-cZapHappinessChange" {
+            self.zap_happiness_change = value.parse::<i32>().unwrap();
+            Ok(format!("Set Zap Happiness Change to {}", self.zap_happiness_change))
+        } else if config == "-cCaptivity" {
+            self.captivity = value.parse::<i32>().unwrap();
+            Ok(format!("Set Captivity to {}", self.captivity))
+        } else if config == "-cReproductionChance" {
+            self.reproduction_chance = value.parse::<i32>().unwrap();
+            Ok(format!("Set Reproduction Chance to {}", self.reproduction_chance))
+        } else if config == "-cReproductionInterval" {
+            self.reproduction_interval = value.parse::<i32>().unwrap();
+            Ok(format!("Set Reproduction Interval to {}", self.reproduction_interval))
+        } else if config == "-cMatingType" {
+            self.mating_type = value.parse::<i32>().unwrap();
+            Ok(format!("Set Mating Type to {}", self.mating_type))
+        } else if config == "-cOffspring" {
+            self.offspring = value.parse::<i32>().unwrap();
+            Ok(format!("Set Offspring to {}", self.offspring))
+        } else if config == "-cKeeperFrequency" {
+            self.keeper_frequency = value.parse::<i32>().unwrap();
+            Ok(format!("Set Keeper Frequency to {}", self.keeper_frequency))
+        } else if config == "-cNotEnoughKeepersChange" {
+            self.not_enough_keepers_change = value.parse::<i32>().unwrap();
+            Ok(format!("Set Not Enough Keepers Change to {}", self.not_enough_keepers_change))
+        } else if config == "-cSocial" {
+            self.social = value.parse::<i32>().unwrap();
+            Ok(format!("Set Social to {}", self.social))
+        } else if config == "-cHabitatSize" {
+            self.habitat_size = value.parse::<i32>().unwrap();
+            Ok(format!("Set Habitat Size to {}", self.habitat_size))
+        } else if config == "-cNumberAnimalsMin" {
+            self.number_animals_min = value.parse::<i32>().unwrap();
+            Ok(format!("Set Number Animals Min to {}", self.number_animals_min))
+        } else if config == "-cNumberAnimalsMax" {
+            self.number_animals_max = value.parse::<i32>().unwrap();
+            Ok(format!("Set Number Animals Max to {}", self.number_animals_max))
+        } else if config == "-cNumberMinChange" {
+            self.number_min_change = value.parse::<i32>().unwrap();
+            Ok(format!("Set Number Min Change to {}", self.number_min_change))
+        } else if config == "-cNumberMaxChange" {
+            self.number_max_change = value.parse::<i32>().unwrap();
+            Ok(format!("Set Number Max Change to {}", self.number_max_change))
+        } else if config == "-cHabitatPreference" {
+            self.habitat_preference = value.parse::<i32>().unwrap();
+            Ok(format!("Set Habitat Preference to {}", self.habitat_preference))
+        } else if config == "-cBabyBornChange" {
+            self.baby_born_change = value.parse::<i32>().unwrap();
+            Ok(format!("Set Baby Born Change to {}", self.baby_born_change))
+        } else if config == "-cEnergyIncrement" {
+            self.energy_increment = value.parse::<i32>().unwrap();
+            Ok(format!("Set Energy Increment to {}", self.energy_increment))
+        } else if config == "-cEnergyThreshold" {
+            self.energy_threshold = value.parse::<i32>().unwrap();
+            Ok(format!("Set Energy Threshold to {}", self.energy_threshold))
+        } else if config == "-cDirtyIncrement" {
+            self.dirty_increment = value.parse::<i32>().unwrap();
+            Ok(format!("Set Dirty Increment to {}", self.dirty_increment))
+        } else if config == "-cDirtyThreshold" {
+            self.dirty_threshold = value.parse::<i32>().unwrap();
+            Ok(format!("Set Dirty Threshold to {}", self.dirty_threshold))
+        } else if config == "-cSickTime" {
+            self.sick_time = value.parse::<i32>().unwrap();
+            Ok(format!("Set Sick Time to {}", self.sick_time))
+        } else if config == "-cBabyToAdult" {
+            self.baby_to_adult = value.parse::<i32>().unwrap();
+            Ok(format!("Set Baby To Adult to {}", self.baby_to_adult))
+        } else if config == "-cOtherFood" {
+            self.other_food = value.parse::<i32>().unwrap();
+            Ok(format!("Set Other Food to {}", self.other_food))
+        } else if config == "-cTreePref" {
+            self.tree_pref = value.parse::<i32>().unwrap();
+            Ok(format!("Set Tree Pref to {}", self.tree_pref))
+        } else if config == "-cRockPref" {
+            self.rock_pref = value.parse::<i32>().unwrap();
+            Ok(format!("Set Rock Pref to {}", self.rock_pref))
+        } else if config == "-cSpacePref" {
+            self.space_pref = value.parse::<i32>().unwrap();
+            Ok(format!("Set Space Pref to {}", self.space_pref))
+        } else if config == "-cElevationPref" {
+            self.elevation_pref = value.parse::<i32>().unwrap();
+            Ok(format!("Set Elevation Pref to {}", self.elevation_pref))
+        } else if config == "-cDepthMin" {
+            self.depth_min = value.parse::<i32>().unwrap();
+            Ok(format!("Set Depth Min to {}", self.depth_min))
+        } else if config == "-cDepthMax" {
+            self.depth_max = value.parse::<i32>().unwrap();
+            Ok(format!("Set Depth Max to {}", self.depth_max))
+        } else if config == "-cDepthChange" {
+            self.depth_change = value.parse::<i32>().unwrap();
+            Ok(format!("Set Depth Change to {}", self.depth_change))
+        } else if config == "-cSalinityChange" {
+            self.salinity_change = value.parse::<i32>().unwrap();
+            Ok(format!("Set Salinity Change to {}", self.salinity_change))
+        } else if config == "-cSalinityHealthChange" {
+            self.salinity_health_change = value.parse::<i32>().unwrap();
+            Ok(format!("Set Salinity Health Change to {}", self.salinity_health_change))
+        } else if config == "-cHappyReproduceThreshold" {
+            self.happy_reproduce_threshold = value.parse::<i32>().unwrap();
+            Ok(format!("Set Happy Reproduce Threshold to {}", self.happy_reproduce_threshold))
+        } else if config == "-cBuildingUseChance" {
+            self.building_use_chance = value.parse::<i32>().unwrap();
+            Ok(format!("Set Building Use Chance to {}", self.building_use_chance))
+        } else if config == "-cNoMateChange" {
+            self.no_mate_change = value.parse::<i32>().unwrap();
+            Ok(format!("Set No Mate Change to {}", self.no_mate_change))
+        } else if config == "-cTimeDeath" {
+            self.time_death = value.parse::<i32>().unwrap();
+            Ok(format!("Set Time Death to {}", self.time_death))
+        } else if config == "-cDeathChance" {
+            self.death_chance = value.parse::<i32>().unwrap();
+            Ok(format!("Set Death Chance to {}", self.death_chance))
+        } else if config == "-cDirtChance" {
+            self.dirt_chance = value.parse::<i32>().unwrap();
+            Ok(format!("Set Dirt Chance to {}", self.dirt_chance))
+        } else if config == "-cWaterNeeded" {
+            self.water_needed = value.parse::<i32>().unwrap();
+            Ok(format!("Set Water Need to {}", self.water_needed))
+        } else {
+            Err("Invalid configuration option")
+        }
+    }
+}
 // ------------ Custom Command Implementation ------------ //
 
 fn command_sel_type(args: Vec<&str>) -> Result<String, &'static str> {


### PR DESCRIPTION
# Overview 

Implemented the `ZTAnimalType` struct which extends the `ZTUnitType` struct. The `ZTAnimalType` struct contains properties for the animal type configuration. The following properties belong to this struct:

- `box_footprint_x: i32`
- `box_footprint_y: i32`
- `box_footprint_z: i32`
- `family: i32`
- `genus: i32`
- `habitat: i32`
- `location: i32`
- `era: i32`
- `breath_threshold: i32`
- `breath_increment: i32`
- `hunger_threshold: i32`
- `hungry_health_change: i32`
- `hunger_increment: i32`
- `food_unit_value: i32`
- `keeper_food_units_eaten: i32`
- `needed_food: i32`
- `no_food_change: i32`
- `initial_happiness: i32`
- `max_hits: i32`
- `pct_hits: i32`
- `max_energy: i32`
- `max_dirty: i32`
- `min_dirty: i32`
- `sick_change: i32`
- `other_animal_sick_change: i32`
- `sick_chance: i32`
- `sick_random_chance: i32`
- `crowd: i32`
- `crowd_happiness_change: i32`
- `zap_happiness_change: i32`
- `captivity: i32`
- `reproduction_chance: i32`
- `reproduction_interval: i32`
- `mating_type: i32`
- `offspring: i32`
- `keeper_frequency: i32`
- `not_enough_keepers_change: i32`
- `social: i32`
- `habitat_size: i32`
- `number_animals_min: i32`
- `number_animals_max: i32`
- `number_min_change: i32`
- `number_max_change: i32`
- `habitat_preference: i32`
- `baby_born_change: i32`
- `energy_increment: i32`
- `energy_threshold: i32`
- `dirty_increment: i32`
- `dirty_threshold: i32`
- `sick_time: i32`
- `baby_to_adult: i32`
- `other_food: i32`
- `tree_pref: i32`
- `rock_pref: i32`
- `space_pref: i32`
- `elevation_pref: i32`
- `depth_min: i32`
- `depth_max: i32`
- `depth_change: i32`
- `salinity_change: i32`
- `salinity_health_change: i32`
- `happy_reproduce_threshold: i32`
- `building_use_chance: i32`
- `no_mate_change: i32`
- `time_death: i32`
- `death_chance: i32`
- `dirt_chance: i32`
- `water_needed: i32`
- `underwater_needed: i32`
- `land_needed: i32`
- `enter_water_chance: i32`
- `enter_tank_chance: i32`
- `enter_land_chance: i32`
- `drink_water_chance: i32`
- `chase_animal_chance: i32`
- `climbs_cliffs: i32`
- `bash_strength: i32`
- `attractiveness: i32`
- `keeper_food_type: i32`
- `is_climber: bool`
- `is_jumper: bool`
- `small_zoodoo: bool`
- `dino_zoodoo: bool`
- `giant_zoodoo: bool`
- `is_special_animal: bool`
- `need_shelter: bool`
- `need_toys: bool`
- `babies_attack: bool`

# Usage 

## Backend 

```rust 
// direct access to the ZTAnimalType struct
let animal_type = ZTAnimalType::new(address).unwrap();
animal_type.box_footprint_x = 10;
animal_type.box_footprint_y = 10;
// alternative way to set the configuration
animal_type.set_config("-cBoxFootprintX", "10");
```

## Console 

```bash
sel_type -v # prints the configuration for the selected entity type
sel_type -v -cBoxFootprintX 10 # sets the Box Footprint X configuration to 10
```