### PR TITLE
Implemented API for all structures under ZTStaffType

### DIFF
--- a/src/bfentitytype.rs
+++ b/src/bfentitytype.rs
@@ -2475,10 +2475,12 @@ impl ZTKeeperType {
         } else if config == "-cCleanTankThreshold" {
             self.clean_tank_threshold = value.parse::<i32>().unwrap();
             Ok(format!("Set Clean Tank Threshold to {}", self.clean_tank_threshold))
-        } else if config == "-cDirt" {
-            self.dirt = value.parse::<u16>().unwrap();
-            Ok(format!("Set Dirt to {}", self.dirt))
-        } else {
+        } 
+        // else if config == "-cDirt" {
+        //     self.dirt = value.parse::<u16>().unwrap();
+        //     Ok(format!("Set Dirt to {}", self.dirt))
+        // } 
+        else {
             Err("Invalid configuration option")
         }
     }

--- a/src/bfentitytype.rs
+++ b/src/bfentitytype.rs
@@ -2379,15 +2379,6 @@ fn print_config_for_type() -> String {
         config.push_str(&rubble_type.print_config_integers());
 
         print_info_image_name(entity_type, &mut config);
-    } else if class_type == "Keeper" || class_type == "MaintenanceWorker" || class_type == "TourGuide" || class_type == "DRT" {
-        info!("Entity type is a ZTUnit. Printing ZTUnit type configuration.");
-        let ztunit_type = ZTUnitType::new(entity_type_address).unwrap(); // create a copied instance of the entity type
-        config.push_str(&ztunit_type.bfunit_type.bfentitytype.print_config_integers());
-        config.push_str(&ztunit_type.bfunit_type.print_config_integers());
-        config.push_str(&ztunit_type.print_config_integers());
-        // config.push_str(&ztunit_type.get_list_name());
-
-        // print_info_image_name(entity_type, &mut config);
     } else if class_type == "Guest" {
         info!("Entity type is a ZTGuest. Printing ZTGuest type configuration.");
         let ztguest_type = ZTGuestType::new(entity_type_address).unwrap(); // create a copied instance of the entity type
@@ -2404,6 +2395,15 @@ fn print_config_for_type() -> String {
         config.push_str(&ztanimal_type.ztunit_type.bfunit_type.print_config_integers());
         config.push_str(&ztanimal_type.ztunit_type.print_config_integers());
         config.push_str(&ztanimal_type.print_config_integers());
+
+        // print_info_image_name(entity_type, &mut config);
+    } else if class_type == "Keeper" || class_type == "MaintenanceWorker" || class_type == "TourGuide" || class_type == "DRT" {
+        info!("Entity type is a ZTStaff. Printing ZTStaff type configuration.");
+        let ztstaff_type = ZTStaffType::new(entity_type_address).unwrap(); // create a copied instance of the entity type
+        config.push_str(&ztstaff_type.ztunit_type.bfunit_type.bfentitytype.print_config_integers());
+        config.push_str(&ztstaff_type.ztunit_type.bfunit_type.print_config_integers());
+        config.push_str(&ztstaff_type.ztunit_type.print_config_integers());
+        config.push_str(&ztstaff_type.print_config_integers());
 
         // print_info_image_name(entity_type, &mut config);
     } else {
@@ -2460,6 +2460,9 @@ fn parse_subargs_for_type(_args: Vec<&str>) -> Result<String, &'static str> {
     let result_ztanimal_type = ZTAnimalType::new(entity_type_address)
         .unwrap()
         .set_config(_args[0], _args[1]);
+    let result_ztstaff_type = ZTStaffType::new(entity_type_address)
+        .unwrap()
+        .set_config(_args[0], _args[1]);
 
     // return the result of the first successful configuration change
     if result_entity_type.is_ok() {
@@ -2488,6 +2491,8 @@ fn parse_subargs_for_type(_args: Vec<&str>) -> Result<String, &'static str> {
         result_ztguest_type
     } else if result_ztanimal_type.is_ok() {
         result_ztanimal_type
+    } else if result_ztstaff_type.is_ok() {
+        result_ztstaff_type
     } else {
         Err("Invalid configuration option")
     }

--- a/src/bfentitytype.rs
+++ b/src/bfentitytype.rs
@@ -2168,6 +2168,75 @@ impl Deref for ZTAnimalType {
     }
 }
 
+// ------------ ZTStaffType, Implementation, and Related Functions ------------ //
+
+#[derive(Debug, Getters, Setters)]
+#[repr(C)]
+struct ZTStaffType {
+    pub ztunit_type: ZTUnitType, // bytes: 0x188 - 0x100 = 0x88 = 136 bytes
+    pad01: [u8; 0x1B4 - 0x188], // ----------------------- padding: 44 bytes
+    pub work_check: i32, // 0x1B4
+    pub chase_check: i32, // 0x1B8
+    pad02: [u8; 0x1BC - 0x1BC], // ----------------------- padding: 4 bytes
+    pub monthly_cost: f32, // 0x1BC
+    // pub training_icon_name: string ptr, // 0x1D8 TODO: implement string ptr as function getter
+    pad03: [u8; 0x1E8 - 0x1C0], // ----------------------- padding: 24 bytes
+    pub duties_text_id: i32, // 0x1E8
+    pub weapon_range: i32, // 0x1EC
+}
+
+impl ZTStaffType {
+    pub fn new(address: u32) -> Option<&'static mut ZTStaffType> {
+        unsafe {
+            let ptr = get_from_memory::<*mut ZTStaffType>(address);
+            if !ptr.is_null() {
+                Some(&mut *ptr)
+            } else {
+                None
+            }
+        }
+    }
+
+    pub fn set_config(&mut self, config: &str, value: &str) -> Result<String, &'static str> {
+        if config == "-cWorkCheck" {
+            self.work_check = value.parse::<i32>().unwrap();
+            Ok(format!("Set Work Check to {}", self.work_check))
+        } else if config == "-cChaseCheck" {
+            self.chase_check = value.parse::<i32>().unwrap();
+            Ok(format!("Set Chase Check to {}", self.chase_check))
+        } else if config == "-cMonthlyCost" {
+            self.monthly_cost = value.parse::<f32>().unwrap();
+            Ok(format!("Set Monthly Cost to {}", self.monthly_cost))
+        } else if config == "-cDutiesTextID" {
+            self.duties_text_id = value.parse::<i32>().unwrap();
+            Ok(format!("Set Duties Text ID to {}", self.duties_text_id))
+        } else if config == "-cWeaponRange" {
+            self.weapon_range = value.parse::<i32>().unwrap();
+            Ok(format!("Set Weapon Range to {}", self.weapon_range))
+        } else {
+            Err("Invalid configuration option")
+        }
+    }
+
+    pub fn print_config_integers(&self) -> String {
+        format!("cWorkCheck: {}\ncChaseCheck: {}\ncMonthlyCost: {}\ncDutiesTextID: {}\ncWeaponRange: {}\n",
+        self.work_check,
+        self.chase_check,
+        self.monthly_cost,
+        self.duties_text_id,
+        self.weapon_range,
+        )
+    }
+}
+
+impl Deref for ZTStaffType {
+    type Target = ZTUnitType;
+
+    fn deref(&self) -> &Self::Target {
+        &self.ztunit_type
+    }
+}
+
 // ------------ Custom Command Implementation ------------ //
 
 fn command_sel_type(args: Vec<&str>) -> Result<String, &'static str> {


### PR DESCRIPTION
This PR intends to implement all structures under the `ZTStaffType` structure, including: `ZTKeeperType`, `ZTMaintType`, `ZTHelicopterType`, and `ZTGuideType`. This initial implementation includes the following for `ZTStaffType`:


# Overview 

The `ZTStaffType` struct is a struct that contains class-level properties for staff types in Zoo Tycoon. It forms a foundation for other structures that extend from it, including: `ZTKeeperType`, `ZTMaintType`, `ZTHelicopterType`, and `ZTGuideType`. The following properties have been implemented:

- `work_check` (i32)
- `chase_check` (i32)
- `monthly_cost` (f32)
- `duties_text_id` (i32)
- `weapon_range` (i32)

# Usage 

## Backend 

```rust 
let staff_type = ZTStaffType::new(address).unwrap();

// Set the work check configuration
let config = staff_type.set_config("-cWorkCheck", "10").unwrap();
// direct manipulation 
staff_type.work_check = 10;
```

## Console 

```bash
# print configuration for the selected entity type
sel_type -v 

# set the work check configuration
sel_type -cWorkCheck 10
```

