### PR TITLE
Custom Keyboard Shortcut System

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -32,7 +32,8 @@
       "Bash(cargo:*)",
       "Bash(git diff:*)",
       "Bash(git --no-pager diff:*)",
-      "Bash(git log:*)"
+      "Bash(git log:*)",
+      "Bash(git fetch:*)"
     ],
     "deny": [],
     "ask": []

--- a/field_accessor_as_string/tests/test.rs
+++ b/field_accessor_as_string/tests/test.rs
@@ -36,6 +36,7 @@ mod tests {
         i8: i8,
         u8: u8,
         bool: bool,
+        #[allow(dead_code)]
         array: [u8; 2],
     }
 

--- a/openzt/Cargo.toml
+++ b/openzt/Cargo.toml
@@ -38,7 +38,7 @@ mlua = { version = "0.11.5", features = ["luajit52", "vendored", "send"] }
 encoding_rs = "0.8"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.62.2", features = ["Win32", "Win32_System_Console", "Win32_System_SystemServices", "Win32_System_Memory", "Win32_Globalization"] }
+windows = { version = "0.62.2", features = ["Win32", "Win32_System_Console", "Win32_System_SystemServices", "Win32_System_Memory", "Win32_Globalization", "Win32_UI_Input_KeyboardAndMouse"] }
 
 [build-dependencies]
 winresource = "0.1"

--- a/openzt/src/experimental.rs
+++ b/openzt/src/experimental.rs
@@ -15,7 +15,6 @@ pub mod zoo_experimental {
     use tracing::info;
     use openzt_detour::gen::bfuimgr::DISPLAY_MESSAGE_0;
 
-    
     // use crate::{
     //     bfregistry::{add_to_registry, get_from_registry},
     //     util::{get_from_memory, get_string_from_memory},

--- a/openzt/src/integration_tests/mod.rs
+++ b/openzt/src/integration_tests/mod.rs
@@ -15,6 +15,7 @@ pub mod disabled_ztd;
 pub mod legacy_attributes;
 pub mod loading_order;
 pub mod patch_rollback;
+pub mod shortcuts;
 
 /// Result of a single test
 #[derive(Debug)]
@@ -290,6 +291,22 @@ mod detour_zoo_main {
         let disabled_ztd_results = super::disabled_ztd::run_all_tests();
 
         for result in &disabled_ztd_results {
+            if result.passed {
+                write_log(&format!("  ✓ {}", result.name));
+                total_passed += 1;
+            } else {
+                write_log(&format!("  ✗ {} - {}", result.name, result.error.as_ref().unwrap_or(&"Unknown error".to_string())));
+                total_failed += 1;
+            }
+        }
+
+        write_log("");
+
+        // Run shortcut tests
+        write_log("Running shortcut tests...");
+        let shortcuts_results = super::shortcuts::run_all_tests();
+
+        for result in &shortcuts_results {
             if result.passed {
                 write_log(&format!("  ✓ {}", result.name));
                 total_passed += 1;

--- a/openzt/src/integration_tests/shortcuts.rs
+++ b/openzt/src/integration_tests/shortcuts.rs
@@ -1,0 +1,346 @@
+//! Integration tests for the keyboard shortcut registration system.
+
+use super::TestResult;
+use crate::shortcuts::{VkKey, register_shortcut, list_shortcuts};
+
+pub fn run_all_tests() -> Vec<TestResult> {
+    vec![
+        test_simple_shortcut_registration(),
+        test_shortcut_with_modifiers(),
+        test_shortcut_conflict_detection(),
+        test_shortcut_override_behavior(),
+        test_multiple_shortcuts_different_keys(),
+        test_list_shortcuts(),
+        test_all_modifiers_combination(),
+    ]
+}
+
+/// Test simple shortcut registration (no modifiers)
+fn test_simple_shortcut_registration() -> TestResult {
+    let test_name = "test_simple_shortcut_registration";
+
+    // Register a simple shortcut
+    let result = register_shortcut(
+        "test_module",
+        "Test F1 shortcut",
+        VkKey::F1,
+        false, false, false,
+        false,
+        || { /* Test callback */ }
+    );
+
+    if result.is_err() {
+        return TestResult::fail(test_name, format!("Registration failed: {:?}", result));
+    }
+
+    // Verify shortcut is in list
+    let list = list_shortcuts();
+    if !list.contains("Test F1 shortcut") {
+        return TestResult::fail(test_name, format!("Shortcut not found in list. List: {}", list));
+    }
+
+    if !list.contains("test_module") {
+        return TestResult::fail(test_name, format!("Module name not found in list. List: {}", list));
+    }
+
+    TestResult::pass(test_name)
+}
+
+/// Test shortcut with Ctrl+Shift+Alt modifiers
+fn test_shortcut_with_modifiers() -> TestResult {
+    let test_name = "test_shortcut_with_modifiers";
+
+    // Register shortcuts with different modifier combinations
+    let ctrl_f2 = register_shortcut(
+        "test_module",
+        "Ctrl+F2 shortcut",
+        VkKey::F2,
+        true, false, false,
+        false,
+        || { /* Ctrl+F2 callback */ }
+    );
+
+    if ctrl_f2.is_err() {
+        return TestResult::fail(test_name, format!("Ctrl+F2 registration failed: {:?}", ctrl_f2));
+    }
+
+    let ctrl_shift_f3 = register_shortcut(
+        "test_module",
+        "Ctrl+Shift+F3 shortcut",
+        VkKey::F3,
+        true, true, false,
+        false,
+        || { /* Ctrl+Shift+F3 callback */ }
+    );
+
+    if ctrl_shift_f3.is_err() {
+        return TestResult::fail(test_name, format!("Ctrl+Shift+F3 registration failed: {:?}", ctrl_shift_f3));
+    }
+
+    let ctrl_shift_alt_f4 = register_shortcut(
+        "test_module",
+        "Ctrl+Shift+Alt+F4 shortcut",
+        VkKey::F4,
+        true, true, true,
+        false,
+        || { /* Ctrl+Shift+Alt+F4 callback */ }
+    );
+
+    if ctrl_shift_alt_f4.is_err() {
+        return TestResult::fail(test_name, format!("Ctrl+Shift+Alt+F4 registration failed: {:?}", ctrl_shift_alt_f4));
+    }
+
+    // Verify all shortcuts are in list
+    let list = list_shortcuts();
+    if !list.contains("Ctrl+F2 shortcut") {
+        return TestResult::fail(test_name, "Ctrl+F2 shortcut not found in list".to_string());
+    }
+    if !list.contains("Ctrl+Shift+F3 shortcut") {
+        return TestResult::fail(test_name, "Ctrl+Shift+F3 shortcut not found in list".to_string());
+    }
+    if !list.contains("Ctrl+Shift+Alt+F4 shortcut") {
+        return TestResult::fail(test_name, "Ctrl+Shift+Alt+F4 shortcut not found in list".to_string());
+    }
+
+    TestResult::pass(test_name)
+}
+
+/// Test that registering duplicate shortcuts fails when override=false
+fn test_shortcut_conflict_detection() -> TestResult {
+    let test_name = "test_shortcut_conflict_detection";
+
+    // Register first shortcut
+    let first = register_shortcut(
+        "module_a",
+        "First F5 shortcut",
+        VkKey::F5,
+        true, false, false,
+        false,
+        || { /* First callback */ }
+    );
+
+    if first.is_err() {
+        return TestResult::fail(test_name, format!("First registration failed: {:?}", first));
+    }
+
+    // Try to register second shortcut with same key+modifiers (should fail)
+    let second = register_shortcut(
+        "module_b",
+        "Second F5 shortcut",
+        VkKey::F5,
+        true, false, false,
+        false,  // override = false
+        || { /* Second callback */ }
+    );
+
+    if second.is_ok() {
+        return TestResult::fail(test_name, "Second registration should have failed but succeeded".to_string());
+    }
+
+    // Verify error message contains expected content
+    let error_msg = second.unwrap_err();
+    if !error_msg.contains("already registered") && !error_msg.contains("module_a") {
+        return TestResult::fail(test_name, format!("Error message unexpected: {}", error_msg));
+    }
+
+    // Verify original shortcut is still in list
+    let list = list_shortcuts();
+    if !list.contains("First F5 shortcut") {
+        return TestResult::fail(test_name, "Original shortcut was replaced".to_string());
+    }
+    if list.contains("Second F5 shortcut") {
+        return TestResult::fail(test_name, "Second shortcut should not be in list".to_string());
+    }
+
+    TestResult::pass(test_name)
+}
+
+/// Test that override=true allows replacing existing shortcuts
+fn test_shortcut_override_behavior() -> TestResult {
+    let test_name = "test_shortcut_override_behavior";
+
+    // Register first shortcut
+    let first = register_shortcut(
+        "module_a",
+        "Original F6 shortcut",
+        VkKey::F6,
+        false, true, false,
+        false,
+        || { /* Original callback */ }
+    );
+
+    if first.is_err() {
+        return TestResult::fail(test_name, format!("First registration failed: {:?}", first));
+    }
+
+    // Register second shortcut with same key+modifiers but override=true
+    let second = register_shortcut(
+        "module_b",
+        "Replacement F6 shortcut",
+        VkKey::F6,
+        false, true, false,
+        true,  // override = true
+        || { /* Replacement callback */ }
+    );
+
+    if second.is_err() {
+        return TestResult::fail(test_name, format!("Override registration failed: {:?}", second));
+    }
+
+    // Verify replacement shortcut is in list
+    let list = list_shortcuts();
+    if !list.contains("Replacement F6 shortcut") {
+        return TestResult::fail(test_name, "Replacement shortcut not found in list".to_string());
+    }
+    if list.contains("Original F6 shortcut") {
+        return TestResult::fail(test_name, "Original shortcut should be replaced".to_string());
+    }
+    if !list.contains("module_b") {
+        return TestResult::fail(test_name, "Module_b not found in list".to_string());
+    }
+
+    TestResult::pass(test_name)
+}
+
+/// Test that multiple shortcuts with different keys can coexist
+fn test_multiple_shortcuts_different_keys() -> TestResult {
+    let test_name = "test_multiple_shortcuts_different_keys";
+
+    // Register multiple shortcuts with different keys
+    let keys = [
+        (VkKey::F7, "F7 action", false, false, false),
+        (VkKey::F8, "F8 action", true, false, false),
+        (VkKey::F9, "F9 action", false, true, false),
+        (VkKey::F10, "F10 action", true, true, false),
+        (VkKey::F11, "F11 action", false, false, true),
+        (VkKey::Num1, "Num1 action", true, true, true),
+        (VkKey::A, "A action", false, false, false),
+    ];
+
+    for (key, desc, ctrl, shift, alt) in &keys {
+        let result = register_shortcut(
+            "multi_test",
+            desc,
+            *key,
+            *ctrl, *shift, *alt,
+            false,
+            || { /* Callback */ }
+        );
+
+        if result.is_err() {
+            return TestResult::fail(test_name, format!("Failed to register {}: {:?}", desc, result));
+        }
+    }
+
+    // Verify all shortcuts are in list
+    let list = list_shortcuts();
+    for (_, desc, _, _, _) in &keys {
+        if !list.contains(desc) {
+            return TestResult::fail(test_name, format!("Shortcut '{}' not found in list", desc));
+        }
+    }
+
+    TestResult::pass(test_name)
+}
+
+/// Test the list_shortcuts function format and content
+fn test_list_shortcuts() -> TestResult {
+    let test_name = "test_list_shortcuts";
+
+    // Clear registry by checking initial state
+    let initial_list = list_shortcuts();
+
+    // Register a few test shortcuts
+    let _ = register_shortcut(
+        "list_test_module",
+        "Test list shortcut A",
+        VkKey::A,
+        false, false, false,
+        false,
+        || { /* Callback A */ }
+    );
+
+    let _ = register_shortcut(
+        "list_test_module",
+        "Test list shortcut B",
+        VkKey::B,
+        true, false, false,
+        false,
+        || { /* Callback B */ }
+    );
+
+    let list = list_shortcuts();
+
+    // Check for expected content
+    if !list.contains("Registered shortcuts:") && !list.contains("No shortcuts registered") {
+        return TestResult::fail(test_name, format!("List format unexpected: {}", list));
+    }
+
+    if !list.contains("Test list shortcut A") {
+        return TestResult::fail(test_name, format!("Shortcut A not found. List: {}", list));
+    }
+
+    if !list.contains("Test list shortcut B") {
+        return TestResult::fail(test_name, format!("Shortcut B not found. List: {}", list));
+    }
+
+    if !list.contains("list_test_module") {
+        return TestResult::fail(test_name, format!("Module name not found. List: {}", list));
+    }
+
+    TestResult::pass(test_name)
+}
+
+/// Test all possible modifier combinations
+fn test_all_modifiers_combination() -> TestResult {
+    let test_name = "test_all_modifiers_combination";
+
+    // Test all 8 possible modifier combinations
+    let combinations = [
+        (false, false, false, "None"),
+        (true, false, false, "Ctrl"),
+        (false, true, false, "Shift"),
+        (false, false, true, "Alt"),
+        (true, true, false, "Ctrl+Shift"),
+        (true, false, true, "Ctrl+Alt"),
+        (false, true, true, "Shift+Alt"),
+        (true, true, true, "Ctrl+Shift+Alt"),
+    ];
+
+    for (i, (ctrl, shift, alt, mod_name)) in combinations.iter().enumerate() {
+        let key = match i {
+            0 => VkKey::Num1,
+            1 => VkKey::Num2,
+            2 => VkKey::Num3,
+            3 => VkKey::Num4,
+            4 => VkKey::Num5,
+            5 => VkKey::Num6,
+            6 => VkKey::Num7,
+            _ => VkKey::Num8,
+        };
+
+        let result = register_shortcut(
+            "modifier_test",
+            &format!("Test with {} modifiers", mod_name),
+            key,
+            *ctrl, *shift, *alt,
+            false,
+            || { /* Callback */ }
+        );
+
+        if result.is_err() {
+            return TestResult::fail(test_name, format!("Failed to register with {}: {:?}", mod_name, result));
+        }
+    }
+
+    // Verify all are in list
+    let list = list_shortcuts();
+    if !list.contains("Test with None modifiers") {
+        return TestResult::fail(test_name, "No-modifier shortcut not found".to_string());
+    }
+    if !list.contains("Test with Ctrl+Shift+Alt modifiers") {
+        return TestResult::fail(test_name, "All-modifier shortcut not found".to_string());
+    }
+
+    TestResult::pass(test_name)
+}

--- a/openzt/src/lib.rs
+++ b/openzt/src/lib.rs
@@ -65,6 +65,9 @@ mod zthabitatmgr;
 
 mod experimental;
 
+/// Keyboard shortcut registration system for game thread callbacks
+mod shortcuts;
+
 /// Patches in the current OpenZT build version into the game's version string.
 mod version;
 
@@ -159,11 +162,11 @@ mod zoo_init {
             ztadvterrainmgr::init();
             ztgamemgr::init();
             experimental::init();
+            shortcuts::init();
             ztmapview::init();
             zthabitatmgr::init();
         }
-        let result = unsafe { LOAD_LANG_DLLS_DETOUR.call(this) };
-        result
+        unsafe { LOAD_LANG_DLLS_DETOUR.call(this) }
     }
 }
 

--- a/openzt/src/mods.rs
+++ b/openzt/src/mods.rs
@@ -509,6 +509,34 @@ pub struct RemoveSectionPatch {
     pub condition: Option<PatchCondition>,
 }
 
+// Test helpers for creating test instances
+#[cfg(test)]
+impl IconDefinition {
+    pub fn new_test(name: String, icon_path: String, icon_palette_path: String) -> Self {
+        IconDefinition {
+            name,
+            icon_path,
+            icon_palette_path,
+        }
+    }
+}
+
+#[cfg(test)]
+impl ModDefinition {
+    pub fn new_test(
+        habitats: Option<std::collections::HashMap<String, IconDefinition>>,
+        locations: Option<std::collections::HashMap<String, IconDefinition>>,
+        patch_meta: Option<PatchMeta>,
+        patches: Option<indexmap::IndexMap<String, Patch>>,
+    ) -> Self {
+        ModDefinition {
+            habitats,
+            locations,
+            patch_meta,
+            patches,
+        }
+    }
+}
 #[cfg(test)]
 mod mod_loading_tests {
     use crate::mods::Version;
@@ -776,31 +804,3 @@ dependencies = [
     }
 }
 
-// Test helpers for creating test instances
-#[cfg(test)]
-impl IconDefinition {
-    pub fn new_test(name: String, icon_path: String, icon_palette_path: String) -> Self {
-        IconDefinition {
-            name,
-            icon_path,
-            icon_palette_path,
-        }
-    }
-}
-
-#[cfg(test)]
-impl ModDefinition {
-    pub fn new_test(
-        habitats: Option<std::collections::HashMap<String, IconDefinition>>,
-        locations: Option<std::collections::HashMap<String, IconDefinition>>,
-        patch_meta: Option<PatchMeta>,
-        patches: Option<indexmap::IndexMap<String, Patch>>,
-    ) -> Self {
-        ModDefinition {
-            habitats,
-            locations,
-            patch_meta,
-            patches,
-        }
-    }
-}

--- a/openzt/src/resource_manager/dependency_resolver.rs
+++ b/openzt/src/resource_manager/dependency_resolver.rs
@@ -633,8 +633,7 @@ impl TarjanState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mods::{Meta, Dependencies, Version};
-    use std::str::FromStr;
+    use crate::mods::{Meta};
 
     /// Helper to create test metadata from TOML string
     fn create_test_meta(toml_str: &str) -> Meta {

--- a/openzt/src/resource_manager/mod_config.rs
+++ b/openzt/src/resource_manager/mod_config.rs
@@ -5,7 +5,6 @@ use std::sync::LazyLock;
 use std::sync::Mutex;
 use tracing::info;
 use tracing_subscriber::filter::LevelFilter;
-use tracing_appender;
 
 static LOGGING_INITIALIZED: LazyLock<Mutex<bool>> = LazyLock::new(|| Mutex::new(false));
 
@@ -500,9 +499,11 @@ mod tests {
     #[test]
     fn test_log_level_serialization() {
         // Test that log levels serialize to lowercase strings within a config
-        let mut config = LoggingConfig::default();
+        let mut config = LoggingConfig {
+            log_to_file: true,
+            level: LogLevel::Trace,
+        };
 
-        config.level = LogLevel::Trace;
         assert!(toml::to_string(&config).unwrap().contains("level = \"trace\""));
 
         config.level = LogLevel::Debug;

--- a/openzt/src/shortcuts.rs
+++ b/openzt/src/shortcuts.rs
@@ -301,4 +301,18 @@ pub fn init() {
     if let Err(e) = unsafe { zoo_shortcuts::init_detours() } {
         tracing::error!("Error initializing shortcut detours: {}", e);
     }
+
+    // Example shortcut: Ctrl+R prints a test message
+    shortcut!(
+        "shortcuts",
+        "Example: Print test message",
+        VkKey::R,
+        true,   // Ctrl
+        false,  // Shift
+        false,  // Alt
+        false,  // override
+        || {
+            tracing::info!("Ctrl+R shortcut triggered! This is an example shortcut.");
+        }
+    );
 }

--- a/openzt/src/shortcuts.rs
+++ b/openzt/src/shortcuts.rs
@@ -2,7 +2,31 @@
 //!
 //! Modules can independently register shortcuts with key+modifier combinations.
 //! The HANDLE_KEY_DOWN detour checks matches before calling the original function.
+//!
+//! # Typestate Pattern
+//!
+//! Shortcuts use a typestate pattern for type-safe modifier construction:
+//!
+//! ```rust
+//! use openzt::shortcuts::{Key, Ctrl, Shift, Alt, VkKey};
+//! use windows::Win32::UI::Input::KeyboardAndMouse::*;
+//!
+//! // Method 1: Using VK constants directly
+//! let ctrl_a = Key::<{ VK_A.0 as i32 }>::new() + Ctrl;
+//!
+//! // Method 2: Using VkKey::code() in a const
+//! const R_KEY: i32 = VkKey::R.code();
+//! let ctrl_r = Key::<R_KEY>::new() + Ctrl;
+//!
+//! // Key with multiple modifiers
+//! let ctrl_shift_a = Key::<{ VK_A.0 as i32 }>::new() + Ctrl + Shift;
+//!
+//! // Register the shortcut
+//! register_shortcut("module", "description", ctrl_shift_a, false, || {});
+//! ```
 
+use std::marker::PhantomData;
+use std::ops::Add;
 use std::sync::LazyLock;
 use windows::Win32::UI::Input::KeyboardAndMouse::*;
 
@@ -92,7 +116,230 @@ impl VkKey {
     }
 }
 
-struct Shortcut {
+// ============================================================================
+// Typestate Pattern for Shortcut Construction
+// ============================================================================
+
+/// Marker type for Ctrl modifier
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Ctrl;
+
+/// Marker type for Alt modifier
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Alt;
+
+/// Marker type for Shift modifier
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Shift;
+
+/// Convenience constants for nicer syntax
+pub const CTRL: Ctrl = Ctrl;
+pub const ALT: Alt = Alt;
+pub const SHIFT: Shift = Shift;
+
+/// A key with a specific virtual key code.
+///
+/// This is the starting point for building shortcuts with modifiers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Key<const CODE: i32>;
+
+impl<const CODE: i32> Key<CODE> {
+    /// Create a new key with the given virtual key code.
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl VkKey {
+    /// Get the virtual key code as a const expression for use with `Key`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// // Using VK constants directly
+    /// let s1 = Key::<{ VK_A.0 as i32 }>::new() + Ctrl;
+    ///
+    /// // Using the convenience code() method
+    /// const A_KEY: i32 = VkKey::A.code();
+    /// let s2 = Key::<A_KEY>::new() + Ctrl;
+    /// ```
+    pub const fn code(self) -> i32 {
+        match self {
+            Self::A => VK_A.0 as i32,
+            Self::B => VK_B.0 as i32,
+            Self::C => VK_C.0 as i32,
+            Self::D => VK_D.0 as i32,
+            Self::E => VK_E.0 as i32,
+            Self::F => VK_F.0 as i32,
+            Self::G => VK_G.0 as i32,
+            Self::H => VK_H.0 as i32,
+            Self::I => VK_I.0 as i32,
+            Self::J => VK_J.0 as i32,
+            Self::K => VK_K.0 as i32,
+            Self::L => VK_L.0 as i32,
+            Self::M => VK_M.0 as i32,
+            Self::N => VK_N.0 as i32,
+            Self::O => VK_O.0 as i32,
+            Self::P => VK_P.0 as i32,
+            Self::Q => VK_Q.0 as i32,
+            Self::R => VK_R.0 as i32,
+            Self::S => VK_S.0 as i32,
+            Self::T => VK_T.0 as i32,
+            Self::U => VK_U.0 as i32,
+            Self::V => VK_V.0 as i32,
+            Self::W => VK_W.0 as i32,
+            Self::X => VK_X.0 as i32,
+            Self::Y => VK_Y.0 as i32,
+            Self::Z => VK_Z.0 as i32,
+            Self::Num0 => VK_0.0 as i32,
+            Self::Num1 => VK_1.0 as i32,
+            Self::Num2 => VK_2.0 as i32,
+            Self::Num3 => VK_3.0 as i32,
+            Self::Num4 => VK_4.0 as i32,
+            Self::Num5 => VK_5.0 as i32,
+            Self::Num6 => VK_6.0 as i32,
+            Self::Num7 => VK_7.0 as i32,
+            Self::Num8 => VK_8.0 as i32,
+            Self::Num9 => VK_9.0 as i32,
+            Self::F1 => VK_F1.0 as i32,
+            Self::F2 => VK_F2.0 as i32,
+            Self::F3 => VK_F3.0 as i32,
+            Self::F4 => VK_F4.0 as i32,
+            Self::F5 => VK_F5.0 as i32,
+            Self::F6 => VK_F6.0 as i32,
+            Self::F7 => VK_F7.0 as i32,
+            Self::F8 => VK_F8.0 as i32,
+            Self::F9 => VK_F9.0 as i32,
+            Self::F10 => VK_F10.0 as i32,
+            Self::F11 => VK_F11.0 as i32,
+            Self::F12 => VK_F12.0 as i32,
+            Self::Space => VK_SPACE.0 as i32,
+            Self::Enter => VK_RETURN.0 as i32,
+            Self::Escape => VK_ESCAPE.0 as i32,
+            Self::Tab => VK_TAB.0 as i32,
+            Self::Backspace => VK_BACK.0 as i32,
+            Self::Insert => VK_INSERT.0 as i32,
+            Self::Delete => VK_DELETE.0 as i32,
+            Self::Home => VK_HOME.0 as i32,
+            Self::End => VK_END.0 as i32,
+            Self::PageUp => VK_PRIOR.0 as i32,
+            Self::PageDown => VK_NEXT.0 as i32,
+            Self::Up => VK_UP.0 as i32,
+            Self::Down => VK_DOWN.0 as i32,
+            Self::Left => VK_LEFT.0 as i32,
+            Self::Right => VK_RIGHT.0 as i32,
+        }
+    }
+}
+
+/// A complete shortcut with type-level modifier states.
+///
+/// The const generics encode the modifier states at compile time, preventing
+/// invalid combinations and enabling efficient matching.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Shortcut<const CTRL: bool, const ALT: bool, const SHIFT: bool, const KEY: i32> {
+    _private: PhantomData<()>,
+}
+
+impl<const CTRL: bool, const ALT: bool, const SHIFT: bool, const KEY: i32>
+    Shortcut<CTRL, ALT, SHIFT, KEY>
+{
+    const fn new() -> Self {
+        Self { _private: PhantomData }
+    }
+
+    /// Check if this shortcut matches the given key+modifier state.
+    pub fn matches(&self, ctrl: bool, alt: bool, shift: bool, key: i32) -> bool {
+        CTRL == ctrl && ALT == alt && SHIFT == shift && KEY == key
+    }
+
+    /// Get the key code for this shortcut.
+    pub const fn key_code(&self) -> i32 {
+        KEY
+    }
+
+    /// Get the Ctrl modifier state.
+    pub const fn ctrl(&self) -> bool {
+        CTRL
+    }
+
+    /// Get the Alt modifier state.
+    pub const fn alt(&self) -> bool {
+        ALT
+    }
+
+    /// Get the Shift modifier state.
+    pub const fn shift(&self) -> bool {
+        SHIFT
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Add implementations for building shortcuts
+// ----------------------------------------------------------------------------
+
+// Key + Modifier -> Shortcut
+impl<const CODE: i32> Add<Ctrl> for Key<CODE> {
+    type Output = Shortcut<true, false, false, CODE>;
+
+    fn add(self, _: Ctrl) -> Self::Output {
+        Shortcut::new()
+    }
+}
+
+impl<const CODE: i32> Add<Alt> for Key<CODE> {
+    type Output = Shortcut<false, true, false, CODE>;
+
+    fn add(self, _: Alt) -> Self::Output {
+        Shortcut::new()
+    }
+}
+
+impl<const CODE: i32> Add<Shift> for Key<CODE> {
+    type Output = Shortcut<false, false, true, CODE>;
+
+    fn add(self, _: Shift) -> Self::Output {
+        Shortcut::new()
+    }
+}
+
+// Shortcut + Modifier (adding modifiers to existing shortcuts)
+impl<const ALT: bool, const SHIFT: bool, const KEY: i32> Add<Ctrl>
+    for Shortcut<false, ALT, SHIFT, KEY>
+{
+    type Output = Shortcut<true, ALT, SHIFT, KEY>;
+
+    fn add(self, _: Ctrl) -> Self::Output {
+        Shortcut::new()
+    }
+}
+
+impl<const CTRL: bool, const SHIFT: bool, const KEY: i32> Add<Alt>
+    for Shortcut<CTRL, false, SHIFT, KEY>
+{
+    type Output = Shortcut<CTRL, true, SHIFT, KEY>;
+
+    fn add(self, _: Alt) -> Self::Output {
+        Shortcut::new()
+    }
+}
+
+impl<const CTRL: bool, const ALT: bool, const KEY: i32> Add<Shift>
+    for Shortcut<CTRL, ALT, false, KEY>
+{
+    type Output = Shortcut<CTRL, ALT, true, KEY>;
+
+    fn add(self, _: Shift) -> Self::Output {
+        Shortcut::new()
+    }
+}
+
+// ============================================================================
+// Shortcut Registry (Runtime storage)
+// ============================================================================
+
+/// Internal representation of a registered shortcut.
+struct RegisteredShortcut {
     module: String,
     description: String,
     key_code: i32,
@@ -102,8 +349,57 @@ struct Shortcut {
     callback: fn(),
 }
 
-static SHORTCUT_REGISTRY: LazyLock<std::sync::Mutex<Vec<Shortcut>>> =
+/// Global registry of all registered shortcuts.
+static SHORTCUT_REGISTRY: LazyLock<std::sync::Mutex<Vec<RegisteredShortcut>>> =
     LazyLock::new(|| std::sync::Mutex::new(Vec::new()));
+
+/// Sealed trait to restrict shortcut registration to typestate shortcuts only.
+mod private {
+    pub trait SealedShortcut {}
+}
+
+impl<const CTRL: bool, const ALT: bool, const SHIFT: bool, const KEY: i32>
+    private::SealedShortcut for Shortcut<CTRL, ALT, SHIFT, KEY>
+{
+}
+
+/// Trait for types that can be registered as shortcuts.
+///
+/// This is sealed to only allow `Shortcut` instances to be registered,
+/// preventing runtime errors from invalid combinations.
+pub trait Registerable: private::SealedShortcut {
+    /// Get the key code.
+    fn key_code(&self) -> i32;
+
+    /// Get the Ctrl modifier state.
+    fn ctrl(&self) -> bool;
+
+    /// Get the Alt modifier state.
+    fn alt(&self) -> bool;
+
+    /// Get the Shift modifier state.
+    fn shift(&self) -> bool;
+}
+
+impl<const CTRL: bool, const ALT: bool, const SHIFT: bool, const KEY: i32> Registerable
+    for Shortcut<CTRL, ALT, SHIFT, KEY>
+{
+    fn key_code(&self) -> i32 {
+        KEY
+    }
+
+    fn ctrl(&self) -> bool {
+        CTRL
+    }
+
+    fn alt(&self) -> bool {
+        ALT
+    }
+
+    fn shift(&self) -> bool {
+        SHIFT
+    }
+}
 
 /// Register a keyboard shortcut.
 ///
@@ -111,10 +407,7 @@ static SHORTCUT_REGISTRY: LazyLock<std::sync::Mutex<Vec<Shortcut>>> =
 ///
 /// * `module` - Name of the module registering the shortcut (for logging/debugging)
 /// * `description` - Human-readable description of what the shortcut does
-/// * `key` - The virtual key to bind to
-/// * `ctrl` - Whether Ctrl modifier is required
-/// * `shift` - Whether Shift modifier is required
-/// * `alt` - Whether Alt modifier is required
+/// * `shortcut` - The shortcut definition (built using typestate pattern)
 /// * `override_existing` - If true, replace existing shortcuts with same key+modifiers
 /// * `callback` - Function to call when shortcut is triggered (runs on game thread)
 ///
@@ -122,23 +415,40 @@ static SHORTCUT_REGISTRY: LazyLock<std::sync::Mutex<Vec<Shortcut>>> =
 ///
 /// * `Ok(())` - Successfully registered
 /// * `Err(String)` - Shortcut already registered and override was false
-pub fn register_shortcut(
+///
+/// # Example
+///
+/// ```rust
+/// use openzt::shortcuts::{Key, Ctrl, Shift};
+///
+/// register_shortcut(
+///     "mymodule",
+///     "Do something cool",
+///     Key::<{ VK_A.0 as i32 }>::new() + Ctrl + Shift,
+///     false,
+///     || {
+///         // Handler code
+///     }
+/// )?;
+/// ```
+pub fn register_shortcut<S: Registerable>(
     module: &str,
     description: &str,
-    key: VkKey,
-    ctrl: bool,
-    shift: bool,
-    alt: bool,
+    shortcut: S,
     override_existing: bool,
     callback: fn(),
 ) -> Result<(), String> {
-    let key_code = key.to_i32();
+    let key_code = shortcut.key_code();
+    let ctrl = shortcut.ctrl();
+    let alt = shortcut.alt();
+    let shift = shortcut.shift();
+
     let mut registry = SHORTCUT_REGISTRY.lock().unwrap();
 
     // Check for existing shortcut with same key+modifiers
-    let existing_idx = registry.iter().position(|s| {
-        s.key_code == key_code && s.ctrl == ctrl && s.shift == shift && s.alt == alt
-    });
+    let existing_idx = registry
+        .iter()
+        .position(|s| s.key_code == key_code && s.ctrl == ctrl && s.shift == shift && s.alt == alt);
 
     match (existing_idx, override_existing) {
         (Some(idx), true) => {
@@ -147,7 +457,7 @@ pub fn register_shortcut(
                 module,
                 registry[idx].module
             );
-            registry[idx] = Shortcut {
+            registry[idx] = RegisteredShortcut {
                 module: module.to_string(),
                 description: description.to_string(),
                 key_code,
@@ -158,12 +468,9 @@ pub fn register_shortcut(
             };
             Ok(())
         }
-        (Some(idx), false) => Err(format!(
-            "Shortcut already registered by module '{}' (use override=true to replace)",
-            registry[idx].module
-        )),
+        (Some(_idx), false) => Err("Shortcut already registered (use override=true to replace)".to_string()),
         (None, _) => {
-            registry.push(Shortcut {
+            registry.push(RegisteredShortcut {
                 module: module.to_string(),
                 description: description.to_string(),
                 key_code,
@@ -236,8 +543,12 @@ pub fn list_shortcuts() -> String {
 
         let key_name = format!("{:#x}", s.key_code);
         result.push_str(&format!(
-            "  [{}{}{}] {} - {}\n",
-            mod_str, key_name, if s.ctrl || s.shift || s.alt { ")" } else { "" }, s.module, s.description
+            "  ({}{}{}) {} - {}\n",
+            mod_str,
+            key_name,
+            if s.ctrl || s.shift || s.alt { ")" } else { "" },
+            s.module,
+            s.description
         ));
     }
     result
@@ -251,10 +562,7 @@ pub fn list_shortcuts() -> String {
 /// shortcut!(
 ///     "ztgamemgr",
 ///     "Add $10,000 to budget",
-///     VkKey::F6,
-///     true,   // Ctrl
-///     false,  // Shift
-///     false,  // Alt
+///     Key::<{ VK_F6.0 as i32 }>::new() + Ctrl,
 ///     false,  // override
 ///     || {
 ///         tracing::info!("Cash added!");
@@ -263,14 +571,11 @@ pub fn list_shortcuts() -> String {
 /// ```
 #[macro_export]
 macro_rules! shortcut {
-    ($module:expr, $description:expr, $key:expr, $ctrl:expr, $shift:expr, $alt:expr, $override:expr, || $body:block) => {
+    ($module:expr, $description:expr, $shortcut:expr, $override:expr, || $body:block) => {
         $crate::shortcuts::register_shortcut(
             $module,
             $description,
-            $key,
-            $ctrl,
-            $shift,
-            $alt,
+            $shortcut,
             $override,
             || $body,
         )
@@ -303,16 +608,89 @@ pub fn init() {
     }
 
     // Example shortcut: Ctrl+R prints a test message
+    const R_KEY: i32 = VkKey::R.code();
     shortcut!(
         "shortcuts",
         "Example: Print test message",
-        VkKey::R,
-        true,   // Ctrl
-        false,  // Shift
-        false,  // Alt
+        Key::<R_KEY>::new() + Ctrl,
         false,  // override
         || {
             tracing::info!("Ctrl+R shortcut triggered! This is an example shortcut.");
         }
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bare_key() {
+        let k = Key::<0x41>::new();
+        let s: Shortcut<true, false, false, 0x41> = k + Ctrl;
+        assert!(s.matches(true, false, false, 0x41));
+    }
+
+    #[test]
+    fn test_key_plus_ctrl() {
+        let k = Key::<0x41>::new();
+        let s = k + Ctrl;
+        assert!(s.matches(true, false, false, 0x41));
+        assert!(!s.matches(false, false, false, 0x41));
+    }
+
+    #[test]
+    fn test_key_plus_alt() {
+        let k = Key::<0x41>::new();
+        let s = k + Alt;
+        assert!(s.matches(false, true, false, 0x41));
+    }
+
+    #[test]
+    fn test_key_plus_shift() {
+        let k = Key::<0x41>::new();
+        let s = k + Shift;
+        assert!(s.matches(false, false, true, 0x41));
+    }
+
+    #[test]
+    fn test_key_plus_ctrl_plus_shift() {
+        let k = Key::<0x41>::new();
+        let s = k + Ctrl + Shift;
+        assert!(s.matches(true, false, true, 0x41));
+    }
+
+    #[test]
+    fn test_key_plus_all_modifiers() {
+        let k = Key::<0x41>::new();
+        let s = k + Ctrl + Alt + Shift;
+        assert!(s.matches(true, true, true, 0x41));
+    }
+
+    #[test]
+    fn test_shortcut_accessors() {
+        let k = Key::<0x41>::new();
+        let s = k + Ctrl + Shift;
+        assert_eq!(s.key_code(), 0x41);
+        assert!(s.ctrl());
+        assert!(!s.alt());
+        assert!(s.shift());
+    }
+
+    #[test]
+    fn test_vkkey_code() {
+        const A_KEY: i32 = VkKey::A.code();
+        let s = Key::<A_KEY>::new() + Ctrl;
+        assert_eq!(s.key_code(), VK_A.0 as i32);
+        assert!(s.ctrl());
+    }
+
+    #[test]
+    fn test_registerable_trait() {
+        let s: Shortcut<true, false, false, 0x41> = Key::<0x41>::new() + Ctrl;
+        assert!(s.ctrl());
+        assert!(!s.alt());
+        assert!(!s.shift());
+        assert_eq!(s.key_code(), 0x41);
+    }
 }

--- a/openzt/src/shortcuts.rs
+++ b/openzt/src/shortcuts.rs
@@ -1,0 +1,304 @@
+//! Keyboard shortcut registration system.
+//!
+//! Modules can independently register shortcuts with key+modifier combinations.
+//! The HANDLE_KEY_DOWN detour checks matches before calling the original function.
+
+use std::sync::LazyLock;
+use windows::Win32::UI::Input::KeyboardAndMouse::*;
+
+/// Common virtual key codes for shortcuts
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VkKey {
+    // Letters
+    A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
+    // Numbers
+    Num0, Num1, Num2, Num3, Num4, Num5, Num6, Num7, Num8, Num9,
+    // Function keys
+    F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12,
+    // Special keys
+    Space, Enter, Escape, Tab, Backspace,
+    Insert, Delete, Home, End,
+    PageUp, PageDown,
+    Up, Down, Left, Right,
+}
+
+impl VkKey {
+    fn to_i32(self) -> i32 {
+        match self {
+            Self::A => VK_A.0 as i32,
+            Self::B => VK_B.0 as i32,
+            Self::C => VK_C.0 as i32,
+            Self::D => VK_D.0 as i32,
+            Self::E => VK_E.0 as i32,
+            Self::F => VK_F.0 as i32,
+            Self::G => VK_G.0 as i32,
+            Self::H => VK_H.0 as i32,
+            Self::I => VK_I.0 as i32,
+            Self::J => VK_J.0 as i32,
+            Self::K => VK_K.0 as i32,
+            Self::L => VK_L.0 as i32,
+            Self::M => VK_M.0 as i32,
+            Self::N => VK_N.0 as i32,
+            Self::O => VK_O.0 as i32,
+            Self::P => VK_P.0 as i32,
+            Self::Q => VK_Q.0 as i32,
+            Self::R => VK_R.0 as i32,
+            Self::S => VK_S.0 as i32,
+            Self::T => VK_T.0 as i32,
+            Self::U => VK_U.0 as i32,
+            Self::V => VK_V.0 as i32,
+            Self::W => VK_W.0 as i32,
+            Self::X => VK_X.0 as i32,
+            Self::Y => VK_Y.0 as i32,
+            Self::Z => VK_Z.0 as i32,
+            Self::Num0 => VK_0.0 as i32,
+            Self::Num1 => VK_1.0 as i32,
+            Self::Num2 => VK_2.0 as i32,
+            Self::Num3 => VK_3.0 as i32,
+            Self::Num4 => VK_4.0 as i32,
+            Self::Num5 => VK_5.0 as i32,
+            Self::Num6 => VK_6.0 as i32,
+            Self::Num7 => VK_7.0 as i32,
+            Self::Num8 => VK_8.0 as i32,
+            Self::Num9 => VK_9.0 as i32,
+            Self::F1 => VK_F1.0 as i32,
+            Self::F2 => VK_F2.0 as i32,
+            Self::F3 => VK_F3.0 as i32,
+            Self::F4 => VK_F4.0 as i32,
+            Self::F5 => VK_F5.0 as i32,
+            Self::F6 => VK_F6.0 as i32,
+            Self::F7 => VK_F7.0 as i32,
+            Self::F8 => VK_F8.0 as i32,
+            Self::F9 => VK_F9.0 as i32,
+            Self::F10 => VK_F10.0 as i32,
+            Self::F11 => VK_F11.0 as i32,
+            Self::F12 => VK_F12.0 as i32,
+            Self::Space => VK_SPACE.0 as i32,
+            Self::Enter => VK_RETURN.0 as i32,
+            Self::Escape => VK_ESCAPE.0 as i32,
+            Self::Tab => VK_TAB.0 as i32,
+            Self::Backspace => VK_BACK.0 as i32,
+            Self::Insert => VK_INSERT.0 as i32,
+            Self::Delete => VK_DELETE.0 as i32,
+            Self::Home => VK_HOME.0 as i32,
+            Self::End => VK_END.0 as i32,
+            Self::PageUp => VK_PRIOR.0 as i32,
+            Self::PageDown => VK_NEXT.0 as i32,
+            Self::Up => VK_UP.0 as i32,
+            Self::Down => VK_DOWN.0 as i32,
+            Self::Left => VK_LEFT.0 as i32,
+            Self::Right => VK_RIGHT.0 as i32,
+        }
+    }
+}
+
+struct Shortcut {
+    module: String,
+    description: String,
+    key_code: i32,
+    ctrl: bool,
+    shift: bool,
+    alt: bool,
+    callback: fn(),
+}
+
+static SHORTCUT_REGISTRY: LazyLock<std::sync::Mutex<Vec<Shortcut>>> =
+    LazyLock::new(|| std::sync::Mutex::new(Vec::new()));
+
+/// Register a keyboard shortcut.
+///
+/// # Arguments
+///
+/// * `module` - Name of the module registering the shortcut (for logging/debugging)
+/// * `description` - Human-readable description of what the shortcut does
+/// * `key` - The virtual key to bind to
+/// * `ctrl` - Whether Ctrl modifier is required
+/// * `shift` - Whether Shift modifier is required
+/// * `alt` - Whether Alt modifier is required
+/// * `override_existing` - If true, replace existing shortcuts with same key+modifiers
+/// * `callback` - Function to call when shortcut is triggered (runs on game thread)
+///
+/// # Returns
+///
+/// * `Ok(())` - Successfully registered
+/// * `Err(String)` - Shortcut already registered and override was false
+pub fn register_shortcut(
+    module: &str,
+    description: &str,
+    key: VkKey,
+    ctrl: bool,
+    shift: bool,
+    alt: bool,
+    override_existing: bool,
+    callback: fn(),
+) -> Result<(), String> {
+    let key_code = key.to_i32();
+    let mut registry = SHORTCUT_REGISTRY.lock().unwrap();
+
+    // Check for existing shortcut with same key+modifiers
+    let existing_idx = registry.iter().position(|s| {
+        s.key_code == key_code && s.ctrl == ctrl && s.shift == shift && s.alt == alt
+    });
+
+    match (existing_idx, override_existing) {
+        (Some(idx), true) => {
+            tracing::warn!(
+                "Shortcut override: {} replacing {} for key combo",
+                module,
+                registry[idx].module
+            );
+            registry[idx] = Shortcut {
+                module: module.to_string(),
+                description: description.to_string(),
+                key_code,
+                ctrl,
+                shift,
+                alt,
+                callback,
+            };
+            Ok(())
+        }
+        (Some(idx), false) => Err(format!(
+            "Shortcut already registered by module '{}' (use override=true to replace)",
+            registry[idx].module
+        )),
+        (None, _) => {
+            registry.push(Shortcut {
+                module: module.to_string(),
+                description: description.to_string(),
+                key_code,
+                ctrl,
+                shift,
+                alt,
+                callback,
+            });
+            tracing::debug!(
+                "Shortcut registered: {} - {} (Ctrl+Shift+Alt: {}{}{} key: {:#x})",
+                module,
+                description,
+                ctrl,
+                shift,
+                alt,
+                key_code
+            );
+            Ok(())
+        }
+    }
+}
+
+/// Check if a key press matches any registered shortcuts.
+///
+/// Returns the callback function if a match is found, None otherwise.
+pub fn check_shortcuts(key_code: i32) -> Option<fn()> {
+    // GetAsyncKeyState returns i16, check high bit (bit 15) for key state
+    let ctrl_pressed = unsafe { GetAsyncKeyState(VK_CONTROL.0 as i32) as u16 } & 0x8000 != 0;
+    let shift_pressed = unsafe { GetAsyncKeyState(VK_SHIFT.0 as i32) as u16 } & 0x8000 != 0;
+    let alt_pressed = unsafe { GetAsyncKeyState(VK_MENU.0 as i32) as u16 } & 0x8000 != 0;
+
+    let registry = SHORTCUT_REGISTRY.lock().unwrap();
+    registry
+        .iter()
+        .find(|s| {
+            s.key_code == key_code
+                && s.ctrl == ctrl_pressed
+                && s.shift == shift_pressed
+                && s.alt == alt_pressed
+        })
+        .map(|s| {
+            tracing::debug!("Shortcut triggered: {} - {}", s.module, s.description);
+            s.callback
+        })
+}
+
+/// List all registered shortcuts as a formatted string.
+pub fn list_shortcuts() -> String {
+    let registry = SHORTCUT_REGISTRY.lock().unwrap();
+    if registry.is_empty() {
+        return "No shortcuts registered.".to_string();
+    }
+
+    let mut result = String::from("Registered shortcuts:\n");
+    for s in registry.iter() {
+        let modifiers: Vec<&str> = vec![
+            if s.ctrl { Some("Ctrl") } else { None },
+            if s.shift { Some("Shift") } else { None },
+            if s.alt { Some("Alt") } else { None },
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
+
+        let mod_str = if modifiers.is_empty() {
+            String::new()
+        } else {
+            format!("{}+", modifiers.join("+"))
+        };
+
+        let key_name = format!("{:#x}", s.key_code);
+        result.push_str(&format!(
+            "  [{}{}{}] {} - {}\n",
+            mod_str, key_name, if s.ctrl || s.shift || s.alt { ")" } else { "" }, s.module, s.description
+        ));
+    }
+    result
+}
+
+/// Macro for registering keyboard shortcuts with ergonomic syntax.
+///
+/// # Example
+///
+/// ```rust
+/// shortcut!(
+///     "ztgamemgr",
+///     "Add $10,000 to budget",
+///     VkKey::F6,
+///     true,   // Ctrl
+///     false,  // Shift
+///     false,  // Alt
+///     false,  // override
+///     || {
+///         tracing::info!("Cash added!");
+///     }
+/// );
+/// ```
+#[macro_export]
+macro_rules! shortcut {
+    ($module:expr, $description:expr, $key:expr, $ctrl:expr, $shift:expr, $alt:expr, $override:expr, || $body:block) => {
+        $crate::shortcuts::register_shortcut(
+            $module,
+            $description,
+            $key,
+            $ctrl,
+            $shift,
+            $alt,
+            $override,
+            || $body,
+        )
+        .unwrap_or_else(|e| tracing::error!("Failed to register shortcut: {}", e))
+    };
+}
+
+use openzt_detour_macro::detour_mod;
+use openzt_detour::gen::ztapp::HANDLE_KEY_DOWN;
+use tracing::info;
+
+#[detour_mod]
+pub mod zoo_shortcuts {
+    use super::*;
+
+    #[detour(HANDLE_KEY_DOWN)]
+    unsafe extern "cdecl" fn handle_key_down(param_1: i32) -> u32 {
+        if let Some(callback) = super::check_shortcuts(param_1) {
+            callback();
+            return 0; // Don't call original function
+        }
+        unsafe { HANDLE_KEY_DOWN_DETOUR.call(param_1) }
+    }
+}
+
+pub fn init() {
+    info!("Initializing keyboard shortcut system");
+    if let Err(e) = unsafe { zoo_shortcuts::init_detours() } {
+        tracing::error!("Error initializing shortcut detours: {}", e);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a keyboard shortcut system with typestate pattern for type-safe modifier construction, enabling readable shortcut definitions like `Ctrl + R` or `Ctrl + Shift + R` (any ordering works).

**Key changes:**
- New `shortcuts.rs` module (850+ lines) with complete shortcut registration system
- Const key items (A-Z, NUM0-NUM9, F1-F12, special keys) for intuitive shortcut creation
- `PartialShortcut` type for incomplete modifier combinations
- `Add` implementations for all modifier+key combinations (key-first and modifier-first)
- HANDLE_KEY_DOWN detour for runtime shortcut detection

**Example usage:**
```rust
use openzt::shortcuts::{Ctrl, Shift, Alt, R};

// All equivalent - key-first or modifier-first
let s1 = R + Ctrl;           // Key-first: R key, then Ctrl modifier
let s2 = Ctrl + R;           // Modifier-first: Ctrl, then R key
let s3 = R + Ctrl + Shift;   // Multiple modifiers
let s4 = Ctrl + Shift + R;   // Modifier-first with multiple

// Register the shortcut
register_shortcut("module", "description", s1, false, || {});
```

## Technical details

**Typestate pattern:** Uses const generics to encode modifier states at compile time:
- `Shortcut<const CTRL: bool, const ALT: bool, const SHIFT: bool, const KEY: i32>`
- Prevents invalid combinations at compile time
- Efficient matching (no runtime hash map lookups)

**Sealed trait:** `Registerable` trait ensures only complete `Shortcut` instances can be registered, not `PartialShortcut` or raw `Key`.

**Const key items:** Pre-defined constants for common keys:
- Letters: `A` through `Z`
- Numbers: `NUM0` through `NUM9`
- Function keys: `F1` through `F12`
- Special keys: `SPACE`, `ENTER`, `ESCAPE`, `TAB`, `BACKSPACE`, `INSERT`, `DELETE`, `HOME`, `END`, `PAGE_UP`, `PAGE_DOWN`
- Arrow keys: `UP`, `DOWN`, `LEFT`, `RIGHT`

## Limitations
Current we don't support individual keys or individual keys with `Shift` as shortcuts so stuff like `R` or `Shift + R` won't work. We have no way to detect if a text input is selected so these shortcuts would fire when the user is typing in text, when we figure out how to handle this case, this limitation will be removed.