### PR TITLE
Allow console to listen on a different ip and port

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,92 @@ end
 
 **Migration Note**: The old command-style syntax (e.g., `add_cash 1000`) is deprecated. Use Lua function calls (e.g., `add_cash(1000)`) instead. See `MIGRATION_TEMPLATE.md` for details on migrating remaining commands.
 
+### Creating Console Commands
+
+Adding new console commands to OpenZT is done using the `lua_fn!` macro in `openzt/src/scripting.rs`. This macro handles function registration, metadata for `help()`, and Lua integration automatically.
+
+#### Registration Location
+
+All commands are registered in the `init()` function in `openzt/src/scripting.rs` (around line 136). Add your command at the end of this function, before the closing brace.
+
+#### Command Patterns
+
+**No Arguments:**
+```rust
+lua_fn!("ping", "Test console connectivity", "ping()", || {
+    Ok("pong".to_string())
+});
+```
+
+**Single Argument:**
+```rust
+lua_fn!("get_string", "Get game string by ID", "get_string(id)", |id: u32| {
+    Ok(format!("String: {}", id))
+});
+```
+
+**Multiple Arguments:**
+```rust
+lua_fn!("set_setting", "Set a configuration value", "set_setting(section, key, value)",
+    |section: String, key: String, value: String| {
+        Ok(format!("Set {}.{} = {}", section, key, value))
+    }
+);
+```
+
+**Optional Arguments:**
+```rust
+lua_fn!("help", "List functions or search by keyword", "help([search_term])",
+    |search: Option<String>| {
+        match search {
+            Some(term) => Ok(format!("Searching for: {}", term)),
+            None => Ok("All functions:".to_string()),
+        }
+    }
+);
+```
+
+#### Return Value Patterns
+
+**Simple string:**
+```rust
+Ok("result".to_string())
+```
+
+**Tuple (value, error):**
+```rust
+Ok(("Success message".to_string(), None::<String>))
+// On error: Ok((String::new(), "Error message".to_string()))
+```
+
+**Unit/void:**
+```rust
+Ok(())
+```
+
+#### Error Handling
+
+Functions should return errors as a tuple with the error string in the second position:
+
+```rust
+lua_fn!("get_entity", "Get entity by ID", "get_entity(id)", |id: u32| {
+    match find_entity(id) {
+        Some(entity) => Ok((entity.name, None::<String>)),
+        None => Ok((String::new(), format!("Entity {} not found", id))),
+    }
+});
+```
+
+In Lua, callers check for errors like:
+```lua
+result, err = get_entity(123)
+if err then
+    print("Error: " .. err)
+else
+    print("Result: " .. result)
+end
+```
+
 ## Architecture Patterns
 
 ### Module Structure

--- a/openzt/src/command_console.rs
+++ b/openzt/src/command_console.rs
@@ -90,7 +90,8 @@ pub mod zoo_console {
 }
 
 pub fn init() {
-    info!("Initializing Lua console on 127.0.0.1:8080");
+    let config = crate::resource_manager::mod_config::get_openzt_config();
+    info!("Initializing Lua console on {}", config.dev.console_listen);
     zoo_console::init();
 }
 
@@ -172,12 +173,15 @@ fn handle_client(mut stream: TcpStream) {
 }
 
 pub fn start_server() {
-    let Ok(listener) = TcpListener::bind("127.0.0.1:8080") else {
-        error!("Failed to bind socket 127.0.0.1:8080, console will not work");
+    let config = crate::resource_manager::mod_config::get_openzt_config();
+    let listen_addr = config.dev.console_listen.clone();
+
+    let Ok(listener) = TcpListener::bind(&listen_addr) else {
+        error!("Failed to bind socket {}, console will not work", listen_addr);
         return;
     };
 
-    info!("Listening on 127.0.0.1:8080...");
+    info!("Listening on {}...", listen_addr);
 
     for stream in listener.incoming() {
         match stream {

--- a/openzt/src/resource_manager/mod_config.rs
+++ b/openzt/src/resource_manager/mod_config.rs
@@ -93,6 +93,9 @@ pub struct OpenZTConfig {
 
     #[serde(default)]
     pub expansions: ExpansionConfig,
+
+    #[serde(default)]
+    pub dev: DevConfig,
 }
 
 /// Mod loading configuration section
@@ -200,8 +203,21 @@ pub struct ExpansionConfig {
     pub custom: IndexMap<String, Vec<String>>,
 }
 
+/// Development tools configuration section
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct DevConfig {
+    /// Console listening address (default: "127.0.0.1:8080")
+    #[serde(default = "default_console_listen")]
+    pub console_listen: String,
+}
+
 fn default_true() -> bool {
     true
+}
+
+fn default_console_listen() -> String {
+    "127.0.0.1:8080".to_string()
 }
 
 fn default_max_memory_mb() -> u32 {
@@ -231,6 +247,7 @@ impl Default for OpenZTConfig {
             },
             resource_cache: ResourceCacheConfig::default(),
             expansions: ExpansionConfig::default(),
+            dev: DevConfig::default(),
         }
     }
 }
@@ -271,6 +288,14 @@ impl Default for ExpansionConfig {
     }
 }
 
+impl Default for DevConfig {
+    fn default() -> Self {
+        DevConfig {
+            console_listen: "127.0.0.1:8080".to_string(),
+        }
+    }
+}
+
 // Global cached configuration
 static CACHED_CONFIG: LazyLock<Mutex<OpenZTConfig>> = LazyLock::new(|| Mutex::new(load_openzt_config_from_disk()));
 
@@ -306,6 +331,7 @@ fn load_openzt_config_from_disk() -> OpenZTConfig {
                     let has_logging = toml_value.get("logging").is_some();
                     let has_resource_cache = toml_value.get("resource_cache").is_some();
                     let has_expansions = toml_value.get("expansions").is_some();
+                    let has_dev = toml_value.get("dev").is_some();
 
                     // Check if all fields exist within sections
                     let mod_loading_complete = if let Some(mod_loading) = toml_value.get("mod_loading") {
@@ -331,6 +357,12 @@ fn load_openzt_config_from_disk() -> OpenZTConfig {
                         false
                     };
 
+                    let dev_complete = if let Some(dev) = toml_value.get("dev") {
+                        dev.get("console_listen").is_some()
+                    } else {
+                        false
+                    };
+
                     // expansions section should always be present (even if empty)
                     // No field-level validation needed for expansions since it's a free-form HashMap
 
@@ -339,9 +371,11 @@ fn load_openzt_config_from_disk() -> OpenZTConfig {
                         || !has_logging
                         || !has_resource_cache
                         || !has_expansions
+                        || !has_dev
                         || !mod_loading_complete
                         || !logging_complete
                         || !resource_cache_complete
+                        || !dev_complete
                 }
                 Err(_) => false, // If we can't parse as Value, the full parse will fail below
             };

--- a/openzt/src/scripting.rs
+++ b/openzt/src/scripting.rs
@@ -559,4 +559,9 @@ pub fn init() {
         crate::roofs::hide_roofs();
         Ok(("Roofs hidden".to_string(), None::<String>))
     });
+
+    // Register the ping() function
+    lua_fn!("ping", "Test console connectivity", "ping()", || {
+        Ok("pong".to_string())
+    });
 }


### PR DESCRIPTION
## Description
Adds a `[dev]` section to `openzt.toml` and a `console_listen` value where you can specify the ip and port for the console to listen on

## Checklist
 - [ ] Docs <!--- Paste Link Here -->
 - [x] Manually tested
 - [ ] Unit tests (where possible) <!--- Usually on relevant for parsing or utility functions -->
