### PR TITLE
OpenZT Console: Add host, help and wait args

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -36,7 +36,12 @@
       "Bash(git fetch:*)",
       "Bash(for:*)",
       "Bash(do)",
-      "Bash(done)"
+      "Bash(done)",
+      "Bash(pkill:*)",
+      "Bash(lsof:*)",
+      "Bash(head:*)",
+      "Bash(jq:*)",
+      "Bash(openzt:*)"
     ],
     "deny": [],
     "ask": []

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,6 +1400,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanospinner"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d11a05424ca9e29356fc1f31a3f165d650c4aa98f0760b3893071163dd2860a2"
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1581,6 +1587,10 @@ dependencies = [
 [[package]]
 name = "openzt-console"
 version = "0.1.0"
+dependencies = [
+ "clap",
+ "nanospinner",
+]
 
 [[package]]
 name = "openzt-detour"

--- a/openzt-console/Cargo.toml
+++ b/openzt-console/Cargo.toml
@@ -9,3 +9,4 @@ repository.workspace = true
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
+nanospinner = "0.1.1"

--- a/openzt-console/Cargo.toml
+++ b/openzt-console/Cargo.toml
@@ -8,3 +8,4 @@ repository.workspace = true
 
 
 [dependencies]
+clap = { version = "4.5", features = ["derive"] }

--- a/openzt-console/src/main.rs
+++ b/openzt-console/src/main.rs
@@ -1,8 +1,38 @@
 use clap::Parser;
+use nanospinner::Spinner;
 use std::io::{self, Read, Write};
 use std::net::TcpStream;
 use std::thread;
 use std::time::Duration;
+
+struct SpinnerHandle {
+    handle: Option<nanospinner::SpinnerHandle>,
+}
+
+impl SpinnerHandle {
+    fn new(message: &str) -> Self {
+        let handle = Spinner::new(message).start();
+        SpinnerHandle { handle: Some(handle) }
+    }
+
+    fn update(&self, message: &str) {
+        if let Some(ref h) = self.handle {
+            h.update(message);
+        }
+    }
+
+    fn success(self, message: &str) {
+        if let Some(h) = self.handle {
+            h.success_with(message);
+        }
+    }
+
+    fn fail(self, message: &str) {
+        if let Some(h) = self.handle {
+            h.fail_with(message);
+        }
+    }
+}
 
 /// OpenZT Lua Console - Interactive runtime scripting console for Zoo Tycoon
 #[derive(Parser, Debug)]
@@ -36,13 +66,8 @@ fn connect_with_wait(host: &str, wait: bool) -> io::Result<TcpStream> {
     if wait {
         loop {
             match TcpStream::connect(host) {
-                Ok(stream) => {
-                    eprintln!("Connected to {}", host);
-                    return Ok(stream);
-                }
-                Err(e) => {
-                    eprintln!("Failed to connect to {}: {}", host, e);
-                    eprintln!("Retrying in 1 second...");
+                Ok(stream) => return Ok(stream),
+                Err(_) => {
                     thread::sleep(Duration::from_secs(1));
                 }
             }
@@ -54,17 +79,38 @@ fn connect_with_wait(host: &str, wait: bool) -> io::Result<TcpStream> {
 
 /// Wait for the console server to be ready by sending ping() until we get pong
 fn wait_for_ready(host: &str, wait: bool) -> io::Result<TcpStream> {
+    let spinner = if wait {
+        Some(SpinnerHandle::new("Waiting for console to initialise..."))
+    } else {
+        None
+    };
+
     loop {
-        let mut stream = connect_with_wait(host, wait)?;
+        // Try to connect
+        if let Some(ref sp) = spinner {
+            sp.update(&format!("Connecting to {}...", host));
+        }
+        let mut stream = match connect_with_wait(host, wait) {
+            Ok(s) => s,
+            Err(e) => {
+                if wait {
+                    continue;
+                } else {
+                    return Err(e);
+                }
+            }
+        };
 
         // Send ping
-        if let Err(e) = stream.write_all(b"ping()") {
+        if let Some(ref sp) = spinner {
+            sp.update("Waiting for server to respond...");
+        }
+        if let Err(_) = stream.write_all(b"ping()") {
             if wait {
-                eprintln!("Failed to send ping: {}, retrying...", e);
                 thread::sleep(Duration::from_secs(1));
                 continue;
             } else {
-                return Err(e);
+                return Err(io::Error::new(io::ErrorKind::Other, "Failed to send ping"));
             }
         }
 
@@ -75,11 +121,13 @@ fn wait_for_ready(host: &str, wait: bool) -> io::Result<TcpStream> {
                 let response = String::from_utf8_lossy(&buffer[0..size]).trim().to_string();
                 if response == "pong" {
                     // Server is ready
+                    if let Some(sp) = spinner {
+                        sp.success(&format!("Connected to {}", host));
+                    }
                     return Ok(stream);
                 } else {
                     // Unexpected response
                     if wait {
-                        eprintln!("Unexpected response: {}, retrying...", response);
                         thread::sleep(Duration::from_secs(1));
                         continue;
                     } else {
@@ -90,14 +138,13 @@ fn wait_for_ready(host: &str, wait: bool) -> io::Result<TcpStream> {
                     }
                 }
             }
-            Err(e) => {
+            Err(_) => {
                 // Connection reset or other error
                 if wait {
-                    eprintln!("Server not ready yet: {}, retrying...", e);
                     thread::sleep(Duration::from_secs(1));
                     continue;
                 } else {
-                    return Err(e);
+                    return Err(io::Error::new(io::ErrorKind::Other, "Failed to read response"));
                 }
             }
         }

--- a/openzt-console/src/main.rs
+++ b/openzt-console/src/main.rs
@@ -1,28 +1,111 @@
+use clap::Parser;
 use std::io::{self, Read, Write};
 use std::net::TcpStream;
+use std::thread;
+use std::time::Duration;
 
-fn main() -> io::Result<()> {
-    let args: Vec<String> = std::env::args().collect();
-    let server_address = "127.0.0.1:8080";
+/// OpenZT Lua Console - Interactive runtime scripting console for Zoo Tycoon
+#[derive(Parser, Debug)]
+#[command(name = "openzt-console")]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    /// Host address to connect to (default: 127.0.0.1:8080)
+    #[arg(short = 'H', long, default_value = "127.0.0.1:8080")]
+    host: String,
 
-    // Check for --oneshot flag
-    if let Some(pos) = args.iter().position(|arg| arg == "--oneshot") {
-        if pos + 1 >= args.len() {
-            eprintln!("Error: --oneshot requires a command argument");
-            eprintln!("Usage: openzt-console --oneshot <command>");
-            std::process::exit(1);
-        }
+    /// Retry connection until successful
+    #[arg(long)]
+    wait: bool,
 
-        let command = &args[pos + 1];
-        return run_oneshot(server_address, command);
-    }
-
-    // Interactive mode (existing behavior)
-    run_interactive(server_address)
+    /// Execute a single command and exit
+    #[arg(long)]
+    oneshot: Option<String>,
 }
 
-fn run_oneshot(server_address: &str, command: &str) -> io::Result<()> {
-    let mut stream = TcpStream::connect(server_address)?;
+fn main() -> io::Result<()> {
+    let cli = Cli::parse();
+
+    if let Some(command) = cli.oneshot {
+        run_oneshot(&cli.host, &command, cli.wait)
+    } else {
+        run_interactive(&cli.host, cli.wait)
+    }
+}
+
+fn connect_with_wait(host: &str, wait: bool) -> io::Result<TcpStream> {
+    if wait {
+        loop {
+            match TcpStream::connect(host) {
+                Ok(stream) => {
+                    eprintln!("Connected to {}", host);
+                    return Ok(stream);
+                }
+                Err(e) => {
+                    eprintln!("Failed to connect to {}: {}", host, e);
+                    eprintln!("Retrying in 1 second...");
+                    thread::sleep(Duration::from_secs(1));
+                }
+            }
+        }
+    } else {
+        TcpStream::connect(host)
+    }
+}
+
+/// Wait for the console server to be ready by sending ping() until we get pong
+fn wait_for_ready(host: &str, wait: bool) -> io::Result<TcpStream> {
+    loop {
+        let mut stream = connect_with_wait(host, wait)?;
+
+        // Send ping
+        if let Err(e) = stream.write_all(b"ping()") {
+            if wait {
+                eprintln!("Failed to send ping: {}, retrying...", e);
+                thread::sleep(Duration::from_secs(1));
+                continue;
+            } else {
+                return Err(e);
+            }
+        }
+
+        // Read response
+        let mut buffer = [0; 1024];
+        match stream.read(&mut buffer) {
+            Ok(size) => {
+                let response = String::from_utf8_lossy(&buffer[0..size]).trim().to_string();
+                if response == "pong" {
+                    // Server is ready
+                    return Ok(stream);
+                } else {
+                    // Unexpected response
+                    if wait {
+                        eprintln!("Unexpected response: {}, retrying...", response);
+                        thread::sleep(Duration::from_secs(1));
+                        continue;
+                    } else {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!("Expected 'pong', got: {}", response)
+                        ));
+                    }
+                }
+            }
+            Err(e) => {
+                // Connection reset or other error
+                if wait {
+                    eprintln!("Server not ready yet: {}, retrying...", e);
+                    thread::sleep(Duration::from_secs(1));
+                    continue;
+                } else {
+                    return Err(e);
+                }
+            }
+        }
+    }
+}
+
+fn run_oneshot(host: &str, command: &str, wait: bool) -> io::Result<()> {
+    let mut stream = wait_for_ready(host, wait)?;
 
     // Send command
     stream.write_all(command.as_bytes())?;
@@ -39,9 +122,9 @@ fn run_oneshot(server_address: &str, command: &str) -> io::Result<()> {
     Ok(())
 }
 
-fn run_interactive(server_address: &str) -> io::Result<()> {
-    let mut stream = TcpStream::connect(server_address)?;
-    println!("Connected to server at {}", server_address);
+fn run_interactive(host: &str, wait: bool) -> io::Result<()> {
+    let mut stream = wait_for_ready(host, wait)?;
+    println!("Connected to server at {}", host);
 
     loop {
         let mut input = String::new();


### PR DESCRIPTION
## Description
Add host, help and wait args. Pretty self explanatory, the `wait` arg waits until it it can send a `ping` command

## Checklist
 - [ ] Docs <!--- Paste Link Here -->
 - [x] Manually tested
 - [ ] Unit tests (where possible) <!--- Usually on relevant for parsing or utility functions -->
