### PR TITLE
Better global accessors

### DIFF
--- a/openzt/Cargo.toml
+++ b/openzt/Cargo.toml
@@ -38,7 +38,7 @@ mlua = { version = "0.11.5", features = ["luajit52", "vendored", "send"] }
 encoding_rs = "0.8"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.62.2", features = ["Win32", "Win32_System_Console", "Win32_System_SystemServices", "Win32_System_Memory", "Win32_Globalization", "Win32_UI_Input_KeyboardAndMouse"] }
+windows = { version = "0.62.2", features = ["Win32", "Win32_System_Console", "Win32_System_SystemServices", "Win32_System_Memory", "Win32_System_LibraryLoader", "Win32_Globalization", "Win32_UI_Input_KeyboardAndMouse"] }
 
 [dev-dependencies]
 

--- a/openzt/src/globals.rs
+++ b/openzt/src/globals.rs
@@ -1,0 +1,241 @@
+//! Centralized registry for accessing global C++ manager instances.
+//!
+//! This module provides a type-safe, lazy-initialized way to access global
+//! manager instances from the injected DLL. It encapsulates pointer chain
+//! resolution and eliminates scattered magic numbers.
+
+use std::ffi::CString;
+use std::marker::PhantomData;
+use std::sync::OnceLock;
+
+// Forward declarations of manager types - these are defined in their respective modules
+// We use opaque pointers here to avoid circular dependencies
+
+/// Opaque type for ZTWorldMgr
+#[repr(C)]
+pub struct ZTWorldMgr {
+    _private: [u8; 0], // Size will be determined by the actual definition
+}
+
+/// Opaque type for ZTHabitatMgr
+#[repr(C)]
+pub struct ZTHabitatMgr {
+    _private: [u8; 0],
+}
+
+/// Opaque type for ZTAdvTerrainMgr_raw
+#[repr(C)]
+pub struct ZTAdvTerrainMgr_raw {
+    _private: [u8; 0],
+}
+
+/// Opaque type for ZTGameMgr
+#[repr(C)]
+pub struct ZTGameMgr {
+    _private: [u8; 0],
+}
+
+/// Opaque type for BFResourceMgr
+#[repr(C)]
+pub struct BFResourceMgr {
+    _private: [u8; 0],
+}
+
+/// Walks a pointer chain and returns the final address.
+///
+/// # Arguments
+/// * `base` - The starting address
+/// * `offsets` - Array of offsets to apply. For all but the last offset,
+///   the address is dereferenced before adding the offset.
+///
+/// # Safety
+/// This function performs raw pointer dereferencing. The caller must ensure
+/// that all addresses in the chain are valid and aligned.
+///
+/// # Example
+/// For offsets `[0]`, this dereferences the base address once (effectively
+/// treating the base as a pointer to a pointer).
+unsafe fn resolve_chain(base: usize, offsets: &[usize]) -> Option<usize> {
+    let mut addr = base;
+    for (i, &offset) in offsets.iter().enumerate() {
+        if i < offsets.len() - 1 {
+            // Dereference for all but the last offset
+            unsafe {
+                addr = *(addr as *const usize);
+            }
+            if addr == 0 {
+                return None;
+            }
+        }
+        addr = addr.wrapping_add(offset);
+    }
+    Some(addr)
+}
+
+/// Cached global instance wrapper for stable singleton objects.
+///
+/// This type is used for global C++ objects that are created once and live
+/// for the lifetime of the game (e.g., manager singletons). The resolved
+/// pointer is cached after the first access to avoid repeated chain resolution.
+pub struct CachedGlobalInstance<T> {
+    base: usize,
+    offsets: &'static [usize],
+    cache: OnceLock<usize>,
+    _marker: PhantomData<*mut T>,
+}
+
+impl<T> CachedGlobalInstance<T> {
+    /// Creates a new cached global instance.
+    ///
+    /// # Arguments
+    /// * `base` - The base address (usually module_base + offset)
+    /// * `offsets` - The pointer chain offsets
+    pub const fn new(base: usize, offsets: &'static [usize]) -> Self {
+        Self {
+            base,
+            offsets,
+            cache: OnceLock::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns a raw pointer to the instance, or null if resolution fails.
+    ///
+    /// The first call resolves the pointer chain and caches the result.
+    /// Subsequent calls return the cached value.
+    pub unsafe fn get(&self) -> *mut T {
+        let addr = self.cache.get_or_init(|| {
+            unsafe { resolve_chain(self.base, self.offsets).unwrap_or(0) }
+        });
+        if *addr == 0 {
+            std::ptr::null_mut()
+        } else {
+            *addr as *mut T
+        }
+    }
+
+    /// Returns a shared reference. Panics if the pointer is null.
+    pub unsafe fn get_ref(&self) -> &T {
+        let ptr = unsafe { self.get() };
+        assert!(!ptr.is_null(), "CachedGlobalInstance pointer is null");
+        unsafe { &*ptr }
+    }
+
+    /// Returns a mutable reference. Panics if the pointer is null.
+    pub unsafe fn get_mut(&self) -> &mut T {
+        let ptr = unsafe { self.get() };
+        assert!(!ptr.is_null(), "CachedGlobalInstance pointer is null");
+        unsafe { &mut *ptr }
+    }
+}
+
+// SAFETY: CachedGlobalInstance only contains plain integers (base address and offsets)
+// and a OnceLock which is thread-safe. It's safe to share across threads.
+unsafe impl<T> Send for CachedGlobalInstance<T> {}
+unsafe impl<T> Sync for CachedGlobalInstance<T> {}
+
+/// Centralized registry for all global manager instances.
+pub struct Globals {
+    ztworldmgr: CachedGlobalInstance<ZTWorldMgr>,
+    zthabitatmgr: CachedGlobalInstance<ZTHabitatMgr>,
+    ztadvterrainmgr: CachedGlobalInstance<ZTAdvTerrainMgr_raw>,
+    ztgamemgr: CachedGlobalInstance<ZTGameMgr>,
+    bfresourcemgr: CachedGlobalInstance<BFResourceMgr>,
+}
+
+impl Globals {
+    /// Returns a mutable reference to the ZTWorldMgr.
+    pub fn ztworldmgr(&self) -> &mut crate::ztworldmgr::ZTWorldMgr {
+        unsafe {
+            // Cast from opaque type to concrete type
+            &mut *(self.ztworldmgr.get_mut() as *mut ZTWorldMgr as *mut crate::ztworldmgr::ZTWorldMgr)
+        }
+    }
+
+    /// Returns a mutable reference to the ZTHabitatMgr.
+    pub fn zthabitatmgr(&self) -> &mut crate::zthabitatmgr::ZTHabitatMgr {
+        unsafe {
+            &mut *(self.zthabitatmgr.get_mut() as *mut ZTHabitatMgr as *mut crate::zthabitatmgr::ZTHabitatMgr)
+        }
+    }
+
+    /// Returns a mutable reference to the ZTAdvTerrainMgr_raw.
+    pub fn ztadvterrainmgr(&self) -> &mut crate::ztadvterrainmgr::ZTAdvTerrainMgr_raw {
+        unsafe {
+            &mut *(self.ztadvterrainmgr.get_mut() as *mut ZTAdvTerrainMgr_raw as *mut crate::ztadvterrainmgr::ZTAdvTerrainMgr_raw)
+        }
+    }
+
+    /// Returns a mutable reference to the ZTGameMgr.
+    pub fn ztgamemgr(&self) -> &mut crate::ztgamemgr::ZTGameMgr {
+        unsafe {
+            &mut *(self.ztgamemgr.get_mut() as *mut ZTGameMgr as *mut crate::ztgamemgr::ZTGameMgr)
+        }
+    }
+
+    /// Returns a mutable reference to the BFResourceMgr.
+    pub fn bfresourcemgr(&self) -> &mut crate::resource_manager::bfresourcemgr::BFResourceMgr {
+        unsafe {
+            &mut *(self.bfresourcemgr.get_mut() as *mut BFResourceMgr as *mut crate::resource_manager::bfresourcemgr::BFResourceMgr)
+        }
+    }
+}
+
+// SAFETY: Globals only contains CachedGlobalInstance values which are Send + Sync
+unsafe impl Send for Globals {}
+unsafe impl Sync for Globals {}
+
+/// Static storage for the globals registry.
+static GLOBALS: OnceLock<Globals> = OnceLock::new();
+
+/// Gets the module base address for the given module name.
+///
+/// # Arguments
+/// * `name` - The name of the module (e.g., "zoo.exe")
+///
+/// # Panics
+/// Panics if the module cannot be found.
+pub fn get_module_base(name: &str) -> usize {
+    let cname = CString::new(name).unwrap();
+    unsafe {
+        windows::Win32::System::LibraryLoader::GetModuleHandleA(
+            windows::core::PCSTR(cname.as_ptr() as _)
+        )
+        .unwrap()
+        .0 as usize
+    }
+}
+
+/// Ensures the globals registry is initialized and returns it.
+///
+/// The registry is lazily initialized on first access. This function is
+/// thread-safe and can be called from any thread.
+fn ensure_globals() -> &'static Globals {
+    GLOBALS.get_or_init(|| {
+        let base = get_module_base("zoo.exe");
+        Globals {
+            // All offsets are &[0] because each address points to a pointer to the struct
+            // (single indirection)
+            ztworldmgr: CachedGlobalInstance::new(base + 0x00638040, &[0]),
+            zthabitatmgr: CachedGlobalInstance::new(base + 0x0063805c, &[0]),
+            ztadvterrainmgr: CachedGlobalInstance::new(base + 0x00638058, &[0]),
+            ztgamemgr: CachedGlobalInstance::new(base + 0x00638048, &[0]),
+            // BFResourceMgr uses empty offsets because the global address points directly
+            // to the struct (no indirection)
+            bfresourcemgr: CachedGlobalInstance::new(base + 0x006380C0, &[]),
+        }
+    })
+}
+
+/// Returns the global manager registry.
+///
+/// This is the main entry point for accessing global managers.
+///
+/// # Example
+/// ```ignore
+/// let world_mgr = crate::globals::globals().ztworldmgr();
+/// println!("Map size: {}x{}", world_mgr.map_x_size, world_mgr.map_y_size);
+/// ```
+pub fn globals() -> &'static Globals {
+    ensure_globals()
+}

--- a/openzt/src/globals.rs
+++ b/openzt/src/globals.rs
@@ -216,13 +216,13 @@ fn ensure_globals() -> &'static Globals {
         Globals {
             // All offsets are &[0] because each address points to a pointer to the struct
             // (single indirection)
-            ztworldmgr: CachedGlobalInstance::new(base + 0x00638040, &[0]),
-            zthabitatmgr: CachedGlobalInstance::new(base + 0x0063805c, &[0]),
-            ztadvterrainmgr: CachedGlobalInstance::new(base + 0x00638058, &[0]),
-            ztgamemgr: CachedGlobalInstance::new(base + 0x00638048, &[0]),
+            ztworldmgr: CachedGlobalInstance::new(base + 0x00238040, &[0]),
+            zthabitatmgr: CachedGlobalInstance::new(base + 0x0023805c, &[0]),
+            ztadvterrainmgr: CachedGlobalInstance::new(base + 0x00238058, &[0]),
+            ztgamemgr: CachedGlobalInstance::new(base + 0x00238048, &[0]),
             // BFResourceMgr uses empty offsets because the global address points directly
             // to the struct (no indirection)
-            bfresourcemgr: CachedGlobalInstance::new(base + 0x006380C0, &[]),
+            bfresourcemgr: CachedGlobalInstance::new(base + 0x002380C0, &[]),
         }
     })
 }
@@ -233,7 +233,7 @@ fn ensure_globals() -> &'static Globals {
 ///
 /// # Example
 /// ```ignore
-/// let world_mgr = crate::globals::globals().ztworldmgr();
+/// let world_mgr = globals().ztworldmgr();
 /// println!("Map size: {}x{}", world_mgr.map_x_size, world_mgr.map_y_size);
 /// ```
 pub fn globals() -> &'static Globals {

--- a/openzt/src/globals.rs
+++ b/openzt/src/globals.rs
@@ -45,30 +45,33 @@ pub struct BFResourceMgr {
 ///
 /// # Arguments
 /// * `base` - The starting address
-/// * `offsets` - Array of offsets to apply. For all but the last offset,
-///   the address is dereferenced before adding the offset.
+/// * `offsets` - Array of offsets to apply:
+///   - `&[]`: Direct access, no dereference
+///   - `&[0]`: Dereference once, add 0
+///   - `&[0, 0x58]`: Dereference, add 0, dereference, add 0x58
 ///
 /// # Safety
 /// This function performs raw pointer dereferencing. The caller must ensure
 /// that all addresses in the chain are valid and aligned.
-///
-/// # Example
-/// For offsets `[0]`, this dereferences the base address once (effectively
-/// treating the base as a pointer to a pointer).
 unsafe fn resolve_chain(base: usize, offsets: &[usize]) -> Option<usize> {
     let mut addr = base;
-    for (i, &offset) in offsets.iter().enumerate() {
-        if i < offsets.len() - 1 {
-            // Dereference for all but the last offset
-            unsafe {
-                addr = *(addr as *const usize);
-            }
-            if addr == 0 {
-                return None;
-            }
+
+    // Empty offsets = direct access, no dereference
+    if offsets.is_empty() {
+        return Some(addr);
+    }
+
+    // For each offset: dereference, then add offset
+    for &offset in offsets {
+        unsafe {
+            addr = *(addr as *const usize);
+        }
+        if addr == 0 {
+            return None;
         }
         addr = addr.wrapping_add(offset);
     }
+
     Some(addr)
 }
 

--- a/openzt/src/globals.rs
+++ b/openzt/src/globals.rs
@@ -113,20 +113,6 @@ impl<T> CachedGlobalInstance<T> {
             *addr as *mut T
         }
     }
-
-    /// Returns a shared reference. Panics if the pointer is null.
-    pub unsafe fn get_ref(&self) -> &T {
-        let ptr = unsafe { self.get() };
-        assert!(!ptr.is_null(), "CachedGlobalInstance pointer is null");
-        unsafe { &*ptr }
-    }
-
-    /// Returns a mutable reference. Panics if the pointer is null.
-    pub unsafe fn get_mut(&self) -> &mut T {
-        let ptr = unsafe { self.get() };
-        assert!(!ptr.is_null(), "CachedGlobalInstance pointer is null");
-        unsafe { &mut *ptr }
-    }
 }
 
 // SAFETY: CachedGlobalInstance only contains plain integers (base address and offsets)
@@ -144,39 +130,73 @@ pub struct Globals {
 }
 
 impl Globals {
-    /// Returns a mutable reference to the ZTWorldMgr.
-    pub fn ztworldmgr(&self) -> &mut crate::ztworldmgr::ZTWorldMgr {
+    /// Returns a shared reference to the ZTWorldMgr (read-only).
+    pub fn ztworldmgr(&self) -> &crate::ztworldmgr::ZTWorldMgr {
         unsafe {
-            // Cast from opaque type to concrete type
-            &mut *(self.ztworldmgr.get_mut() as *mut ZTWorldMgr as *mut crate::ztworldmgr::ZTWorldMgr)
+            &*(self.ztworldmgr.get() as *const crate::ztworldmgr::ZTWorldMgr)
         }
     }
 
-    /// Returns a mutable reference to the ZTHabitatMgr.
-    pub fn zthabitatmgr(&self) -> &mut crate::zthabitatmgr::ZTHabitatMgr {
+    /// Returns a raw mutable pointer to the ZTWorldMgr for mutation.
+    pub fn ztworldmgr_ptr(&self) -> *mut crate::ztworldmgr::ZTWorldMgr {
         unsafe {
-            &mut *(self.zthabitatmgr.get_mut() as *mut ZTHabitatMgr as *mut crate::zthabitatmgr::ZTHabitatMgr)
+            self.ztworldmgr.get() as *mut crate::ztworldmgr::ZTWorldMgr
         }
     }
 
-    /// Returns a mutable reference to the ZTAdvTerrainMgr_raw.
-    pub fn ztadvterrainmgr(&self) -> &mut crate::ztadvterrainmgr::ZTAdvTerrainMgr_raw {
+    /// Returns a shared reference to the ZTHabitatMgr (read-only).
+    pub fn zthabitatmgr(&self) -> &crate::zthabitatmgr::ZTHabitatMgr {
         unsafe {
-            &mut *(self.ztadvterrainmgr.get_mut() as *mut ZTAdvTerrainMgr_raw as *mut crate::ztadvterrainmgr::ZTAdvTerrainMgr_raw)
+            &*(self.zthabitatmgr.get() as *const crate::zthabitatmgr::ZTHabitatMgr)
         }
     }
 
-    /// Returns a mutable reference to the ZTGameMgr.
-    pub fn ztgamemgr(&self) -> &mut crate::ztgamemgr::ZTGameMgr {
+    /// Returns a raw mutable pointer to the ZTHabitatMgr for mutation.
+    pub fn zthabitatmgr_ptr(&self) -> *mut crate::zthabitatmgr::ZTHabitatMgr {
         unsafe {
-            &mut *(self.ztgamemgr.get_mut() as *mut ZTGameMgr as *mut crate::ztgamemgr::ZTGameMgr)
+            self.zthabitatmgr.get() as *mut crate::zthabitatmgr::ZTHabitatMgr
         }
     }
 
-    /// Returns a mutable reference to the BFResourceMgr.
-    pub fn bfresourcemgr(&self) -> &mut crate::resource_manager::bfresourcemgr::BFResourceMgr {
+    /// Returns a shared reference to the ZTAdvTerrainMgr_raw (read-only).
+    pub fn ztadvterrainmgr(&self) -> &crate::ztadvterrainmgr::ZTAdvTerrainMgr_raw {
         unsafe {
-            &mut *(self.bfresourcemgr.get_mut() as *mut BFResourceMgr as *mut crate::resource_manager::bfresourcemgr::BFResourceMgr)
+            &*(self.ztadvterrainmgr.get() as *const crate::ztadvterrainmgr::ZTAdvTerrainMgr_raw)
+        }
+    }
+
+    /// Returns a raw mutable pointer to the ZTAdvTerrainMgr_raw for mutation.
+    pub fn ztadvterrainmgr_ptr(&self) -> *mut crate::ztadvterrainmgr::ZTAdvTerrainMgr_raw {
+        unsafe {
+            self.ztadvterrainmgr.get() as *mut crate::ztadvterrainmgr::ZTAdvTerrainMgr_raw
+        }
+    }
+
+    /// Returns a shared reference to the ZTGameMgr (read-only).
+    pub fn ztgamemgr(&self) -> &crate::ztgamemgr::ZTGameMgr {
+        unsafe {
+            &*(self.ztgamemgr.get() as *const crate::ztgamemgr::ZTGameMgr)
+        }
+    }
+
+    /// Returns a raw mutable pointer to the ZTGameMgr for mutation.
+    pub fn ztgamemgr_ptr(&self) -> *mut crate::ztgamemgr::ZTGameMgr {
+        unsafe {
+            self.ztgamemgr.get() as *mut crate::ztgamemgr::ZTGameMgr
+        }
+    }
+
+    /// Returns a shared reference to the BFResourceMgr (read-only).
+    pub fn bfresourcemgr(&self) -> &crate::resource_manager::bfresourcemgr::BFResourceMgr {
+        unsafe {
+            &*(self.bfresourcemgr.get() as *const crate::resource_manager::bfresourcemgr::BFResourceMgr)
+        }
+    }
+
+    /// Returns a raw mutable pointer to the BFResourceMgr for mutation.
+    pub fn bfresourcemgr_ptr(&self) -> *mut crate::resource_manager::bfresourcemgr::BFResourceMgr {
+        unsafe {
+            self.bfresourcemgr.get() as *mut crate::resource_manager::bfresourcemgr::BFResourceMgr
         }
     }
 }

--- a/openzt/src/lib.rs
+++ b/openzt/src/lib.rs
@@ -1,4 +1,7 @@
 #![allow(dead_code)]
+/// Centralized registry for accessing global C++ manager instances
+mod globals;
+
 /// Reimplementation of the BFRegistry, a vanilla system used to store pointers to the ZT*Mgr classes. In theory this
 /// allowed customization via zoo.ini, but in practice it appears unused.
 mod bfregistry;

--- a/openzt/src/resource_manager.rs
+++ b/openzt/src/resource_manager.rs
@@ -1,4 +1,4 @@
-mod bfresourcemgr;
+pub(crate) mod bfresourcemgr;
 mod commands;
 mod handlers;
 mod hooks;

--- a/openzt/src/resource_manager/bfresourcemgr.rs
+++ b/openzt/src/resource_manager/bfresourcemgr.rs
@@ -4,6 +4,7 @@ use public::public;
 use tracing::{error, info};
 
 use crate::util::{get_from_memory, ZTBoundedString, ZTString, ZTStringPtr};
+use crate::globals::globals;
 
 #[public]
 #[derive(Debug)]
@@ -91,7 +92,7 @@ impl Display for BFResourcePtr {
 
 pub fn read_bf_resource_dir_contents_from_memory() -> Vec<BFResourceDirContents> {
     info!("Reading BFResourceDir from memory");
-    let bf_resource_mgr = crate::globals::globals().bfresourcemgr();
+    let bf_resource_mgr = globals().bfresourcemgr();
     let mut bf_resource_dir_contents: Vec<BFResourceDirContents> = Vec::new();
     let mut bf_resource_dir_ptr = bf_resource_mgr.resource_array_start;
     let mut bf_resource_zips: Vec<BFResourceZip> = Vec::new();

--- a/openzt/src/resource_manager/bfresourcemgr.rs
+++ b/openzt/src/resource_manager/bfresourcemgr.rs
@@ -5,8 +5,6 @@ use tracing::{error, info};
 
 use crate::util::{get_from_memory, ZTBoundedString, ZTString, ZTStringPtr};
 
-const GLOBAL_BFRESOURCEMGR_ADDRESS: u32 = 0x006380C0;
-
 #[public]
 #[derive(Debug)]
 #[repr(C)]
@@ -90,13 +88,10 @@ impl Display for BFResourcePtr {
     }
 }
 
-pub fn read_bf_resource_mgr_from_memory() -> BFResourceMgr {
-    get_from_memory::<BFResourceMgr>(GLOBAL_BFRESOURCEMGR_ADDRESS)
-}
 
 pub fn read_bf_resource_dir_contents_from_memory() -> Vec<BFResourceDirContents> {
     info!("Reading BFResourceDir from memory");
-    let bf_resource_mgr = read_bf_resource_mgr_from_memory();
+    let bf_resource_mgr = crate::globals::globals().bfresourcemgr();
     let mut bf_resource_dir_contents: Vec<BFResourceDirContents> = Vec::new();
     let mut bf_resource_dir_ptr = bf_resource_mgr.resource_array_start;
     let mut bf_resource_zips: Vec<BFResourceZip> = Vec::new();

--- a/openzt/src/resource_manager/commands.rs
+++ b/openzt/src/resource_manager/commands.rs
@@ -2,7 +2,7 @@ use crate::{
     command_console::CommandError,
     lua_fn,
     resource_manager::{
-        bfresourcemgr::{read_bf_resource_dir_contents_from_memory, read_bf_resource_mgr_from_memory},
+        bfresourcemgr::read_bf_resource_dir_contents_from_memory,
         lazyresourcemap::{decrement_ref, get_cache_stats, get_file_names, get_ref_count, increment_ref, unload_all_resources, UnloadResult},
         openzt_mods::{get_location_habitat_ids, get_mod_ids},
     },
@@ -186,7 +186,7 @@ fn command_list_resources(_args: Vec<&str>) -> Result<String, CommandError> {
 }
 
 fn command_get_bf_resource_mgr(_args: Vec<&str>) -> Result<String, CommandError> {
-    let bf_resource_mgr = read_bf_resource_mgr_from_memory();
+    let bf_resource_mgr = crate::globals::globals().bfresourcemgr();
     Ok(format!("{}", bf_resource_mgr))
 }
 

--- a/openzt/src/resource_manager/commands.rs
+++ b/openzt/src/resource_manager/commands.rs
@@ -1,5 +1,6 @@
 use crate::{
     command_console::CommandError,
+    globals::globals,
     lua_fn,
     resource_manager::{
         bfresourcemgr::read_bf_resource_dir_contents_from_memory,
@@ -186,7 +187,7 @@ fn command_list_resources(_args: Vec<&str>) -> Result<String, CommandError> {
 }
 
 fn command_get_bf_resource_mgr(_args: Vec<&str>) -> Result<String, CommandError> {
-    let bf_resource_mgr = crate::globals::globals().bfresourcemgr();
+    let bf_resource_mgr = globals().bfresourcemgr();
     Ok(format!("{}", bf_resource_mgr))
 }
 

--- a/openzt/src/roofs.rs
+++ b/openzt/src/roofs.rs
@@ -8,7 +8,6 @@ use crate::resource_manager::openzt_mods::legacy_attributes::LegacyEntityType;
 use crate::runtime_state;
 use crate::shortcuts::{Ctrl, R};
 use crate::util::get_from_memory;
-use crate::ztworldmgr::read_zt_world_mgr_from_global;
 
 #[cfg(target_os = "windows")]
 use openzt_detour_macro::detour_mod;
@@ -120,7 +119,7 @@ pub fn hide_roofs() {
     info!("Looking for {} roof-tagged base strings: {:?}", roof_bases.len(), roof_bases);
 
     // Get all in-game entities
-    let zt_world_mgr = read_zt_world_mgr_from_global();
+    let zt_world_mgr = crate::globals::globals().ztworldmgr();
     let entity_array_start = zt_world_mgr.entity_array_start();
     let entity_array_end = zt_world_mgr.entity_array_end();
 
@@ -195,7 +194,7 @@ pub fn show_roofs() {
     }
 
     // Get all entities and show roof-tagged ones
-    let zt_world_mgr = read_zt_world_mgr_from_global();
+    let zt_world_mgr = crate::globals::globals().ztworldmgr();
     let entity_array_start = zt_world_mgr.entity_array_start();
     let entity_array_end = zt_world_mgr.entity_array_end();
 

--- a/openzt/src/roofs.rs
+++ b/openzt/src/roofs.rs
@@ -3,6 +3,7 @@
 use std::collections::HashSet;
 use tracing::info;
 
+use crate::globals::globals;
 use crate::resource_manager::openzt_mods::extensions::{get_extension, list_extensions_with_tag, register_tag, EntityScope};
 use crate::resource_manager::openzt_mods::legacy_attributes::LegacyEntityType;
 use crate::runtime_state;
@@ -119,7 +120,7 @@ pub fn hide_roofs() {
     info!("Looking for {} roof-tagged base strings: {:?}", roof_bases.len(), roof_bases);
 
     // Get all in-game entities
-    let zt_world_mgr = crate::globals::globals().ztworldmgr();
+    let zt_world_mgr = globals().ztworldmgr();
     let entity_array_start = zt_world_mgr.entity_array_start();
     let entity_array_end = zt_world_mgr.entity_array_end();
 
@@ -194,7 +195,7 @@ pub fn show_roofs() {
     }
 
     // Get all entities and show roof-tagged ones
-    let zt_world_mgr = crate::globals::globals().ztworldmgr();
+    let zt_world_mgr = globals().ztworldmgr();
     let entity_array_start = zt_world_mgr.entity_array_start();
     let entity_array_end = zt_world_mgr.entity_array_end();
 

--- a/openzt/src/ztadvterrainmgr.rs
+++ b/openzt/src/ztadvterrainmgr.rs
@@ -4,6 +4,7 @@ use tracing::info;
 
 use crate::{
     command_console::CommandError,
+    globals::globals,
     lua_fn,
     util::{get_from_memory, ZTBufferString},
 };
@@ -70,7 +71,7 @@ struct BFTerrainTypeInfo {
 
 
 fn read_ztadvterrainmgr_from_memory() -> ZTAdvTerrainMgr {
-    ZTAdvTerrainMgr::from(*crate::globals::globals().ztadvterrainmgr())
+    ZTAdvTerrainMgr::from(*globals().ztadvterrainmgr())
 }
 
 fn read_bfterraintypeinfo_from_memory(address: u32) -> BFTerrainTypeInfo {

--- a/openzt/src/ztadvterrainmgr.rs
+++ b/openzt/src/ztadvterrainmgr.rs
@@ -8,12 +8,11 @@ use crate::{
     util::{get_from_memory, ZTBufferString},
 };
 
-const GLOBAL_ZTADVTERRAINMGR_ADDRESS: u32 = 0x00638058;
 const BFTERRAINTYPEINFO_SIZE: usize = 0x30;
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 #[repr(C)]
-struct ZTAdvTerrainMgr_raw {
+pub struct ZTAdvTerrainMgr_raw {
     vtable: u32,
     unknown_u32_1: u32,
     unknown_u32_2: u32,
@@ -69,12 +68,9 @@ struct BFTerrainTypeInfo {
     icon_string: ZTBufferString,
 }
 
-fn read_ztadvterrainmgr_raw_from_memory() -> ZTAdvTerrainMgr_raw {
-    get_from_memory(get_from_memory::<u32>(GLOBAL_ZTADVTERRAINMGR_ADDRESS))
-}
 
 fn read_ztadvterrainmgr_from_memory() -> ZTAdvTerrainMgr {
-    ZTAdvTerrainMgr::from(read_ztadvterrainmgr_raw_from_memory())
+    ZTAdvTerrainMgr::from(*crate::globals::globals().ztadvterrainmgr())
 }
 
 fn read_bfterraintypeinfo_from_memory(address: u32) -> BFTerrainTypeInfo {

--- a/openzt/src/ztgamemgr.rs
+++ b/openzt/src/ztgamemgr.rs
@@ -1,13 +1,11 @@
 use tracing::info;
 
-use crate::{command_console::CommandError, lua_fn, util::get_from_memory};
-
-const GLOBAL_ZTGAMEMGR_ADDRESS: u32 = 0x00638048;
+use crate::{command_console::CommandError, lua_fn};
 
 /// ZTGameMgr struct
 #[derive(Debug)]
 #[repr(C)]
-struct ZTGameMgr {
+pub struct ZTGameMgr {
     pad1: [u8; 0x0C],
     cash: f32,                     // 0x0C
     pad2: [u8; 0x30 - 0x10],       // 0x0C
@@ -64,28 +62,12 @@ impl ZTGameMgr {
             *(enable_dev_mode_address as *mut bool) = enable;
         }
     }
-
-    /// returns the instance of the ZTGameMgr struct
-    fn instance() -> Option<&'static mut ZTGameMgr> {
-        unsafe {
-            // get the pointer to the ZTGameMgr instance
-            let ptr = get_from_memory::<*mut ZTGameMgr>(GLOBAL_ZTGAMEMGR_ADDRESS);
-
-            // is pointer null
-            if !ptr.is_null() {
-                Some(&mut *ptr)
-            } else {
-                // pointer is null
-                None
-            }
-        }
-    }
 }
 
 /// a command that prints the SYSTEMTIME struct in memory in a human-readable format
 /// usage: `get_date`
 pub fn command_get_date_str(_args: Vec<&str>) -> Result<String, CommandError> {
-    let ztgamemgr = ZTGameMgr::instance().ok_or("Failed to get ZTGameMgr instance")?;
+    let ztgamemgr = crate::globals::globals().ztgamemgr();
     let date = ztgamemgr.date.clone();
     info!("Date: {:#?}", date);
 
@@ -98,7 +80,7 @@ pub fn command_get_date_str(_args: Vec<&str>) -> Result<String, CommandError> {
 /// a command that adds cash to the player's account
 /// usage: `add_cash <amount>`
 pub fn command_add_cash(args: Vec<&str>) -> Result<String, CommandError> {
-    let ztgamemgr = ZTGameMgr::instance().ok_or("Failed to get ZTGameMgr instance")?;
+    let ztgamemgr = crate::globals::globals().ztgamemgr();
     ztgamemgr.cash += args[0].parse::<f32>()?;
     Ok(format!("Added ${}", args[0]))
 }
@@ -114,7 +96,7 @@ pub fn command_enable_dev_mode(args: Vec<&str>) -> Result<String, CommandError> 
 /// a command that prints various stats about the zoo
 /// usage: `zoostats`
 pub fn command_zoostats(_args: Vec<&str>) -> Result<String, CommandError> {
-    let ztgamemgr = ZTGameMgr::instance().ok_or("Failed to get ZTGameMgr instance")?;
+    let ztgamemgr = crate::globals::globals().ztgamemgr();
     Ok(format!("\nBudget: {}\nAnimals: {}\nSpecies: {}\nTired Guests: {}\nHungry Guests: {}\nThirsty Guests: {}\nGuests Need Restroom: {}\nNum Guests: {}\nZoo Admission Cost: ${}", ztgamemgr.cash, ztgamemgr.num_animals, ztgamemgr.num_species, ztgamemgr.num_tired_guests, ztgamemgr.num_hungry_guests, ztgamemgr.num_thirst_guests, ztgamemgr.num_guests_restroom_need, ztgamemgr.num_guests, ztgamemgr.zoo_admission_cost))
 }
 

--- a/openzt/src/ztgamemgr.rs
+++ b/openzt/src/ztgamemgr.rs
@@ -1,6 +1,6 @@
 use tracing::info;
 
-use crate::{command_console::CommandError, lua_fn};
+use crate::{command_console::CommandError, globals::globals, lua_fn};
 
 /// ZTGameMgr struct
 #[derive(Debug)]
@@ -67,7 +67,7 @@ impl ZTGameMgr {
 /// a command that prints the SYSTEMTIME struct in memory in a human-readable format
 /// usage: `get_date`
 pub fn command_get_date_str(_args: Vec<&str>) -> Result<String, CommandError> {
-    let ztgamemgr = crate::globals::globals().ztgamemgr();
+    let ztgamemgr = globals().ztgamemgr();
     let date = ztgamemgr.date.clone();
     info!("Date: {:#?}", date);
 
@@ -80,7 +80,7 @@ pub fn command_get_date_str(_args: Vec<&str>) -> Result<String, CommandError> {
 /// a command that adds cash to the player's account
 /// usage: `add_cash <amount>`
 pub fn command_add_cash(args: Vec<&str>) -> Result<String, CommandError> {
-    let ztgamemgr = crate::globals::globals().ztgamemgr();
+    let ztgamemgr = globals().ztgamemgr();
     ztgamemgr.cash += args[0].parse::<f32>()?;
     Ok(format!("Added ${}", args[0]))
 }
@@ -96,7 +96,7 @@ pub fn command_enable_dev_mode(args: Vec<&str>) -> Result<String, CommandError> 
 /// a command that prints various stats about the zoo
 /// usage: `zoostats`
 pub fn command_zoostats(_args: Vec<&str>) -> Result<String, CommandError> {
-    let ztgamemgr = crate::globals::globals().ztgamemgr();
+    let ztgamemgr = globals().ztgamemgr();
     Ok(format!("\nBudget: {}\nAnimals: {}\nSpecies: {}\nTired Guests: {}\nHungry Guests: {}\nThirsty Guests: {}\nGuests Need Restroom: {}\nNum Guests: {}\nZoo Admission Cost: ${}", ztgamemgr.cash, ztgamemgr.num_animals, ztgamemgr.num_species, ztgamemgr.num_tired_guests, ztgamemgr.num_hungry_guests, ztgamemgr.num_thirst_guests, ztgamemgr.num_guests_restroom_need, ztgamemgr.num_guests, ztgamemgr.zoo_admission_cost))
 }
 

--- a/openzt/src/ztgamemgr.rs
+++ b/openzt/src/ztgamemgr.rs
@@ -80,8 +80,10 @@ pub fn command_get_date_str(_args: Vec<&str>) -> Result<String, CommandError> {
 /// a command that adds cash to the player's account
 /// usage: `add_cash <amount>`
 pub fn command_add_cash(args: Vec<&str>) -> Result<String, CommandError> {
-    let ztgamemgr = globals().ztgamemgr();
-    ztgamemgr.cash += args[0].parse::<f32>()?;
+    let ptr = globals().ztgamemgr_ptr();
+    unsafe {
+        (*ptr).cash += args[0].parse::<f32>()?;
+    }
     Ok(format!("Added ${}", args[0]))
 }
 

--- a/openzt/src/zthabitatmgr.rs
+++ b/openzt/src/zthabitatmgr.rs
@@ -7,6 +7,7 @@ use getset::Getters;
 
 use crate::{
     command_console::CommandError,
+    globals::globals,
     lua_fn,
     util::{get_from_memory, ZTArray, ZTBoundedString, ZTString},
     ztmapview::BFTile,
@@ -136,12 +137,12 @@ impl ZTHabitat {
         let tile = get_from_memory::<BFTile>(self.entrance_tile_ptr);
         // info!("Entrance tile: {}", tile);
 
-        let zthm = crate::globals::globals().zthabitatmgr();
+        let zthm = globals().zthabitatmgr();
         if let Some(gate_habitat) = zthm.get_habitat_by_tile(&tile)
             && gate_habitat == *self {
                 return Some(tile);
             }
-        let ztwm = crate::globals::globals().ztworldmgr();
+        let ztwm = globals().ztworldmgr();
         ztwm.get_neighbour(&tile, Direction::from(self.entrance_rotation))
     }
 }
@@ -205,12 +206,12 @@ impl fmt::Display for ZTHabitat {
 }
 
 fn command_get_zt_habitat_mgr(_args: Vec<&str>) -> Result<String, CommandError> {
-    let zt_habitat_mgr = crate::globals::globals().zthabitatmgr();
+    let zt_habitat_mgr = globals().zthabitatmgr();
     Ok(format!("{}", zt_habitat_mgr))
 }
 
 fn command_get_zt_habitats(_args: Vec<&str>) -> Result<String, CommandError> {
-    let zt_habitat_mgr = crate::globals::globals().zthabitatmgr();
+    let zt_habitat_mgr = globals().zthabitatmgr();
     let mut result_string = String::new();
     for i in 0..zt_habitat_mgr.exhibit_array.len() {
         let habitat = zt_habitat_mgr.exhibit_array.get(i);
@@ -242,7 +243,7 @@ pub mod hooks_zthabitatmgr {
     unsafe extern "thiscall" fn get_gate_tile_in(_this: u32) -> u32 {
         let habitat = get_from_memory::<ZTHabitat>(_this);
         match habitat.get_gate_tile_in() {
-            Some(tile) => crate::globals::globals().ztworldmgr().get_ptr_from_bftile(&tile),
+            Some(tile) => globals().ztworldmgr().get_ptr_from_bftile(&tile),
             None => 0,
         }
     }

--- a/openzt/src/zthabitatmgr.rs
+++ b/openzt/src/zthabitatmgr.rs
@@ -10,10 +10,8 @@ use crate::{
     lua_fn,
     util::{get_from_memory, ZTArray, ZTBoundedString, ZTString},
     ztmapview::BFTile,
-    ztworldmgr::{read_zt_world_mgr_from_global, Direction},
+    ztworldmgr::Direction,
 };
-
-pub const GLOBAL_ZTHABITATMGR_ADDRESS: u32 = 0x0063805c;
 
 /// ZTHabitatMgr struct
 #[derive(Debug)]
@@ -98,9 +96,6 @@ impl fmt::Display for ZTHabitatMgr {
     }
 }
 
-pub fn read_zt_habitat_mgr_from_memory() -> ZTHabitatMgr {
-    get_from_memory::<ZTHabitatMgr>(get_from_memory(GLOBAL_ZTHABITATMGR_ADDRESS))
-}
 
 #[derive(Debug, Getters)]
 #[repr(C)]
@@ -141,12 +136,12 @@ impl ZTHabitat {
         let tile = get_from_memory::<BFTile>(self.entrance_tile_ptr);
         // info!("Entrance tile: {}", tile);
 
-        let zthm = read_zt_habitat_mgr_from_memory();
+        let zthm = crate::globals::globals().zthabitatmgr();
         if let Some(gate_habitat) = zthm.get_habitat_by_tile(&tile)
             && gate_habitat == *self {
                 return Some(tile);
             }
-        let ztwm = read_zt_world_mgr_from_global();
+        let ztwm = crate::globals::globals().ztworldmgr();
         ztwm.get_neighbour(&tile, Direction::from(self.entrance_rotation))
     }
 }
@@ -210,12 +205,12 @@ impl fmt::Display for ZTHabitat {
 }
 
 fn command_get_zt_habitat_mgr(_args: Vec<&str>) -> Result<String, CommandError> {
-    let zt_habitat_mgr = read_zt_habitat_mgr_from_memory();
+    let zt_habitat_mgr = crate::globals::globals().zthabitatmgr();
     Ok(format!("{}", zt_habitat_mgr))
 }
 
 fn command_get_zt_habitats(_args: Vec<&str>) -> Result<String, CommandError> {
-    let zt_habitat_mgr = read_zt_habitat_mgr_from_memory();
+    let zt_habitat_mgr = crate::globals::globals().zthabitatmgr();
     let mut result_string = String::new();
     for i in 0..zt_habitat_mgr.exhibit_array.len() {
         let habitat = zt_habitat_mgr.exhibit_array.get(i);
@@ -247,7 +242,7 @@ pub mod hooks_zthabitatmgr {
     unsafe extern "thiscall" fn get_gate_tile_in(_this: u32) -> u32 {
         let habitat = get_from_memory::<ZTHabitat>(_this);
         match habitat.get_gate_tile_in() {
-            Some(tile) => read_zt_world_mgr_from_global().get_ptr_from_bftile(&tile),
+            Some(tile) => crate::globals::globals().ztworldmgr().get_ptr_from_bftile(&tile),
             None => 0,
         }
     }

--- a/openzt/src/ztmapview.rs
+++ b/openzt/src/ztmapview.rs
@@ -4,6 +4,7 @@ use openzt_detour_macro::detour_mod;
 use tracing::info;
 
 use crate::bfentitytype::{zt_entity_type_class_is, ZTEntityTypeClass};
+use crate::globals::globals;
 use crate::util::get_from_memory;
 use crate::ztworldmgr::{BFEntity, IVec3};
 // use crate::{
@@ -290,7 +291,7 @@ impl ZTMapView {
     pub fn check_tank_placement(temp_entity_ptr: u32, tile: &BFTile) -> Result<(), ErrorStringId> {
         info!("Entity Ptr {:#x} -> {:#x}", temp_entity_ptr, get_from_memory::<u32>(temp_entity_ptr));
         let temp_entity: BFEntity = get_from_memory(temp_entity_ptr);
-        let habitat_mgr = crate::globals::globals().zthabitatmgr();
+        let habitat_mgr = globals().zthabitatmgr();
         let Some(habitat) = habitat_mgr.get_habitat(tile.pos.x, tile.pos.y) else {
             info!("No habitat found at tile position: {:?}", tile.pos);
             return Ok(());

--- a/openzt/src/ztmapview.rs
+++ b/openzt/src/ztmapview.rs
@@ -5,7 +5,6 @@ use tracing::info;
 
 use crate::bfentitytype::{zt_entity_type_class_is, ZTEntityTypeClass};
 use crate::util::get_from_memory;
-use crate::zthabitatmgr::read_zt_habitat_mgr_from_memory;
 use crate::ztworldmgr::{BFEntity, IVec3};
 // use crate::{
 //     util::get_from_memory,
@@ -291,7 +290,7 @@ impl ZTMapView {
     pub fn check_tank_placement(temp_entity_ptr: u32, tile: &BFTile) -> Result<(), ErrorStringId> {
         info!("Entity Ptr {:#x} -> {:#x}", temp_entity_ptr, get_from_memory::<u32>(temp_entity_ptr));
         let temp_entity: BFEntity = get_from_memory(temp_entity_ptr);
-        let habitat_mgr = read_zt_habitat_mgr_from_memory();
+        let habitat_mgr = crate::globals::globals().zthabitatmgr();
         let Some(habitat) = habitat_mgr.get_habitat(tile.pos.x, tile.pos.y) else {
             info!("No habitat found at tile position: {:?}", tile.pos);
             return Ok(());

--- a/openzt/src/ztworldmgr.rs
+++ b/openzt/src/ztworldmgr.rs
@@ -552,7 +552,7 @@ fn log_zt_world_mgr(zt_world_mgr: &ZTWorldMgr) {
 
 fn command_get_zt_world_mgr_entities(_args: Vec<&str>) -> Result<String, CommandError> {
     let zt_world_mgr = globals().ztworldmgr();
-    let entities = get_zt_world_mgr_entities(&zt_world_mgr);
+    let entities = get_zt_world_mgr_entities(zt_world_mgr);
     info!("Found {} entities", entities.len());
     if entities.is_empty() {
         return Ok("No entities found".to_string());
@@ -566,7 +566,7 @@ fn command_get_zt_world_mgr_entities(_args: Vec<&str>) -> Result<String, Command
 
 fn command_get_zt_world_mgr_entities_2(_args: Vec<&str>) -> Result<String, CommandError> {
     let zt_world_mgr = globals().ztworldmgr();
-    let entities = get_zt_world_mgr_entities_2(&zt_world_mgr);
+    let entities = get_zt_world_mgr_entities_2(zt_world_mgr);
     info!("Found {} entities", entities.len());
     if entities.is_empty() {
         return Ok("No entities found".to_string());
@@ -590,7 +590,7 @@ fn command_get_entity_unique_vtable_entries(args: Vec<&str>) -> Result<String, C
     };
 
     let zt_world_mgr = globals().ztworldmgr();
-    let entities = get_zt_world_mgr_entities(&zt_world_mgr);
+    let entities = get_zt_world_mgr_entities(zt_world_mgr);
 
     let mut result = String::new();
 
@@ -616,7 +616,7 @@ fn command_get_entity_type_unique_vtable_entries(args: Vec<&str>) -> Result<Stri
     };
 
     let zt_world_mgr = globals().ztworldmgr();
-    let entities = get_zt_world_mgr_types(&zt_world_mgr);
+    let entities = get_zt_world_mgr_types(zt_world_mgr);
 
     let mut result = String::new();
 
@@ -633,7 +633,7 @@ fn command_get_entity_type_unique_vtable_entries(args: Vec<&str>) -> Result<Stri
 
 fn command_get_zt_world_mgr_types(_args: Vec<&str>) -> Result<String, CommandError> {
     let zt_world_mgr = globals().ztworldmgr();
-    let types = get_zt_world_mgr_types(&zt_world_mgr);
+    let types = get_zt_world_mgr_types(zt_world_mgr);
     info!("Found {} types", types.len());
     if types.is_empty() {
         return Ok("No types found".to_string());
@@ -652,7 +652,7 @@ fn command_get_zt_world_mgr(_args: Vec<&str>) -> Result<String, CommandError> {
 
 fn command_zt_world_mgr_types_summary(_args: Vec<&str>) -> Result<String, CommandError> {
     let zt_world_mgr = globals().ztworldmgr();
-    let types = get_zt_world_mgr_types(&zt_world_mgr);
+    let types = get_zt_world_mgr_types(zt_world_mgr);
     let mut summary = "\n".to_string();
     let mut subtype: HashMap<String, u32> = HashMap::new();
     if types.is_empty() {

--- a/openzt/src/ztworldmgr.rs
+++ b/openzt/src/ztworldmgr.rs
@@ -13,6 +13,7 @@ use crate::ztmapview::BFTile;
 use crate::{
     bfentitytype::{read_zt_entity_type_from_memory, BFEntityType, ZTEntityType, ZTSceneryType},
     command_console::CommandError,
+    globals::globals,
     lua_fn,
     util::{get_from_memory, get_string_from_memory, map_from_memory},
 };
@@ -154,7 +155,7 @@ impl BFEntity {
 
         let rect = self.get_blocking_rect();
         let tile_size = IVec3 { x: 0x20, y: 0x20, z: 0 };
-        rect.contains_point(&crate::globals::globals().ztworldmgr().tile_to_world(tile.pos, tile_size))
+        rect.contains_point(&globals().ztworldmgr().tile_to_world(tile.pos, tile_size))
     }
 
     pub fn get_blocking_rect(&self) -> Rectangle {
@@ -212,7 +213,7 @@ impl BFEntity {
     }
 
     pub fn get_tile(&self) -> Option<BFTile> {
-        crate::globals::globals().ztworldmgr().get_tile_from_coords(self.x_coord, self.y_coord)
+        globals().ztworldmgr().get_tile_from_coords(self.x_coord, self.y_coord)
     }
 }
 
@@ -395,7 +396,7 @@ pub mod hooks_ztworldmgr {
 
     #[detour(GET_NEIGHBOR_1)]
     unsafe extern "thiscall" fn bfmap_get_neighbour(_this: u32, bftile: u32, direction: u32) -> u32 {
-        let ztwm = crate::globals::globals().ztworldmgr();
+        let ztwm = globals().ztworldmgr();
         let bftile = get_from_memory::<BFTile>(bftile);
         let direction = Direction::from(direction);
         match ztwm.get_neighbour(&bftile, direction) {
@@ -435,7 +436,7 @@ pub mod hooks_ztworldmgr {
     // // 0040f26c BFPos * __thiscall OOAnalyzer::BFMap::tileToWorld(BFMap *this,BFPos *param_1,BFPos *param_2,BFPos *param_3)
     #[detour(TILE_TO_WORLD)]
     unsafe extern "thiscall" fn bfmap_tile_to_world(_this: u32, param_1: u32, param_2: u32, param_3: u32) -> u32 {
-        let ztwm = crate::globals::globals().ztworldmgr();
+        let ztwm = globals().ztworldmgr();
         let tile_pos = get_from_memory::<IVec3>(param_2);
         let local_pos = get_from_memory::<IVec3>(param_3);
         let world_pos = ztwm.tile_to_world(tile_pos, local_pos);
@@ -550,7 +551,7 @@ fn log_zt_world_mgr(zt_world_mgr: &ZTWorldMgr) {
 }
 
 fn command_get_zt_world_mgr_entities(_args: Vec<&str>) -> Result<String, CommandError> {
-    let zt_world_mgr = crate::globals::globals().ztworldmgr();
+    let zt_world_mgr = globals().ztworldmgr();
     let entities = get_zt_world_mgr_entities(&zt_world_mgr);
     info!("Found {} entities", entities.len());
     if entities.is_empty() {
@@ -564,7 +565,7 @@ fn command_get_zt_world_mgr_entities(_args: Vec<&str>) -> Result<String, Command
 }
 
 fn command_get_zt_world_mgr_entities_2(_args: Vec<&str>) -> Result<String, CommandError> {
-    let zt_world_mgr = crate::globals::globals().ztworldmgr();
+    let zt_world_mgr = globals().ztworldmgr();
     let entities = get_zt_world_mgr_entities_2(&zt_world_mgr);
     info!("Found {} entities", entities.len());
     if entities.is_empty() {
@@ -588,7 +589,7 @@ fn command_get_entity_unique_vtable_entries(args: Vec<&str>) -> Result<String, C
         None => u32::from_str(args[0])?,
     };
 
-    let zt_world_mgr = crate::globals::globals().ztworldmgr();
+    let zt_world_mgr = globals().ztworldmgr();
     let entities = get_zt_world_mgr_entities(&zt_world_mgr);
 
     let mut result = String::new();
@@ -614,7 +615,7 @@ fn command_get_entity_type_unique_vtable_entries(args: Vec<&str>) -> Result<Stri
         None => u32::from_str(args[0])?,
     };
 
-    let zt_world_mgr = crate::globals::globals().ztworldmgr();
+    let zt_world_mgr = globals().ztworldmgr();
     let entities = get_zt_world_mgr_types(&zt_world_mgr);
 
     let mut result = String::new();
@@ -631,7 +632,7 @@ fn command_get_entity_type_unique_vtable_entries(args: Vec<&str>) -> Result<Stri
 }
 
 fn command_get_zt_world_mgr_types(_args: Vec<&str>) -> Result<String, CommandError> {
-    let zt_world_mgr = crate::globals::globals().ztworldmgr();
+    let zt_world_mgr = globals().ztworldmgr();
     let types = get_zt_world_mgr_types(&zt_world_mgr);
     info!("Found {} types", types.len());
     if types.is_empty() {
@@ -645,12 +646,12 @@ fn command_get_zt_world_mgr_types(_args: Vec<&str>) -> Result<String, CommandErr
 }
 
 fn command_get_zt_world_mgr(_args: Vec<&str>) -> Result<String, CommandError> {
-    let zt_world_mgr = crate::globals::globals().ztworldmgr();
+    let zt_world_mgr = globals().ztworldmgr();
     Ok(zt_world_mgr.to_string())
 }
 
 fn command_zt_world_mgr_types_summary(_args: Vec<&str>) -> Result<String, CommandError> {
-    let zt_world_mgr = crate::globals::globals().ztworldmgr();
+    let zt_world_mgr = globals().ztworldmgr();
     let types = get_zt_world_mgr_types(&zt_world_mgr);
     let mut summary = "\n".to_string();
     let mut subtype: HashMap<String, u32> = HashMap::new();
@@ -722,7 +723,7 @@ fn get_zt_world_mgr_types(zt_world_mgr: &ZTWorldMgr) -> Vec<ZTEntityType> {
 }
 
 pub fn get_entity_type_by_id(id: u32) -> u32 {
-    let zt_world_mgr = crate::globals::globals().ztworldmgr();
+    let zt_world_mgr = globals().ztworldmgr();
     let entity_type_array_start = zt_world_mgr.entity_type_array_start;
     let entity_type_array_end = zt_world_mgr.entity_type_array_end;
 

--- a/openzt/src/ztworldmgr.rs
+++ b/openzt/src/ztworldmgr.rs
@@ -17,7 +17,6 @@ use crate::{
     util::{get_from_memory, get_string_from_memory, map_from_memory},
 };
 
-const GLOBAL_ZTWORLDMGR_ADDRESS: u32 = 0x00638040;
 
 #[derive(Debug, PartialEq, Eq, FromPrimitive, Clone)]
 #[repr(u32)]
@@ -155,7 +154,7 @@ impl BFEntity {
 
         let rect = self.get_blocking_rect();
         let tile_size = IVec3 { x: 0x20, y: 0x20, z: 0 };
-        rect.contains_point(&read_zt_world_mgr_from_global().tile_to_world(tile.pos, tile_size))
+        rect.contains_point(&crate::globals::globals().ztworldmgr().tile_to_world(tile.pos, tile_size))
     }
 
     pub fn get_blocking_rect(&self) -> Rectangle {
@@ -213,7 +212,7 @@ impl BFEntity {
     }
 
     pub fn get_tile(&self) -> Option<BFTile> {
-        read_zt_world_mgr_from_global().get_tile_from_coords(self.x_coord, self.y_coord)
+        crate::globals::globals().ztworldmgr().get_tile_from_coords(self.x_coord, self.y_coord)
     }
 }
 
@@ -396,7 +395,7 @@ pub mod hooks_ztworldmgr {
 
     #[detour(GET_NEIGHBOR_1)]
     unsafe extern "thiscall" fn bfmap_get_neighbour(_this: u32, bftile: u32, direction: u32) -> u32 {
-        let ztwm = read_zt_world_mgr_from_global();
+        let ztwm = crate::globals::globals().ztworldmgr();
         let bftile = get_from_memory::<BFTile>(bftile);
         let direction = Direction::from(direction);
         match ztwm.get_neighbour(&bftile, direction) {
@@ -436,7 +435,7 @@ pub mod hooks_ztworldmgr {
     // // 0040f26c BFPos * __thiscall OOAnalyzer::BFMap::tileToWorld(BFMap *this,BFPos *param_1,BFPos *param_2,BFPos *param_3)
     #[detour(TILE_TO_WORLD)]
     unsafe extern "thiscall" fn bfmap_tile_to_world(_this: u32, param_1: u32, param_2: u32, param_3: u32) -> u32 {
-        let ztwm = read_zt_world_mgr_from_global();
+        let ztwm = crate::globals::globals().ztworldmgr();
         let tile_pos = get_from_memory::<IVec3>(param_2);
         let local_pos = get_from_memory::<IVec3>(param_3);
         let world_pos = ztwm.tile_to_world(tile_pos, local_pos);
@@ -545,17 +544,13 @@ pub fn read_zt_entity_from_memory(zt_entity_ptr: u32) -> ZTEntity {
     }
 }
 
-pub fn read_zt_world_mgr_from_global() -> ZTWorldMgr {
-    let zt_world_mgr_ptr = get_from_memory::<u32>(GLOBAL_ZTWORLDMGR_ADDRESS);
-    get_from_memory::<ZTWorldMgr>(zt_world_mgr_ptr)
-}
 
 fn log_zt_world_mgr(zt_world_mgr: &ZTWorldMgr) {
     info!("zt_world_mgr: {:#?}", zt_world_mgr);
 }
 
 fn command_get_zt_world_mgr_entities(_args: Vec<&str>) -> Result<String, CommandError> {
-    let zt_world_mgr = read_zt_world_mgr_from_global();
+    let zt_world_mgr = crate::globals::globals().ztworldmgr();
     let entities = get_zt_world_mgr_entities(&zt_world_mgr);
     info!("Found {} entities", entities.len());
     if entities.is_empty() {
@@ -569,7 +564,7 @@ fn command_get_zt_world_mgr_entities(_args: Vec<&str>) -> Result<String, Command
 }
 
 fn command_get_zt_world_mgr_entities_2(_args: Vec<&str>) -> Result<String, CommandError> {
-    let zt_world_mgr = read_zt_world_mgr_from_global();
+    let zt_world_mgr = crate::globals::globals().ztworldmgr();
     let entities = get_zt_world_mgr_entities_2(&zt_world_mgr);
     info!("Found {} entities", entities.len());
     if entities.is_empty() {
@@ -593,7 +588,7 @@ fn command_get_entity_unique_vtable_entries(args: Vec<&str>) -> Result<String, C
         None => u32::from_str(args[0])?,
     };
 
-    let zt_world_mgr = read_zt_world_mgr_from_global();
+    let zt_world_mgr = crate::globals::globals().ztworldmgr();
     let entities = get_zt_world_mgr_entities(&zt_world_mgr);
 
     let mut result = String::new();
@@ -619,7 +614,7 @@ fn command_get_entity_type_unique_vtable_entries(args: Vec<&str>) -> Result<Stri
         None => u32::from_str(args[0])?,
     };
 
-    let zt_world_mgr = read_zt_world_mgr_from_global();
+    let zt_world_mgr = crate::globals::globals().ztworldmgr();
     let entities = get_zt_world_mgr_types(&zt_world_mgr);
 
     let mut result = String::new();
@@ -636,7 +631,7 @@ fn command_get_entity_type_unique_vtable_entries(args: Vec<&str>) -> Result<Stri
 }
 
 fn command_get_zt_world_mgr_types(_args: Vec<&str>) -> Result<String, CommandError> {
-    let zt_world_mgr = read_zt_world_mgr_from_global();
+    let zt_world_mgr = crate::globals::globals().ztworldmgr();
     let types = get_zt_world_mgr_types(&zt_world_mgr);
     info!("Found {} types", types.len());
     if types.is_empty() {
@@ -650,12 +645,12 @@ fn command_get_zt_world_mgr_types(_args: Vec<&str>) -> Result<String, CommandErr
 }
 
 fn command_get_zt_world_mgr(_args: Vec<&str>) -> Result<String, CommandError> {
-    let zt_world_mgr = read_zt_world_mgr_from_global();
+    let zt_world_mgr = crate::globals::globals().ztworldmgr();
     Ok(zt_world_mgr.to_string())
 }
 
 fn command_zt_world_mgr_types_summary(_args: Vec<&str>) -> Result<String, CommandError> {
-    let zt_world_mgr = read_zt_world_mgr_from_global();
+    let zt_world_mgr = crate::globals::globals().ztworldmgr();
     let types = get_zt_world_mgr_types(&zt_world_mgr);
     let mut summary = "\n".to_string();
     let mut subtype: HashMap<String, u32> = HashMap::new();
@@ -727,7 +722,7 @@ fn get_zt_world_mgr_types(zt_world_mgr: &ZTWorldMgr) -> Vec<ZTEntityType> {
 }
 
 pub fn get_entity_type_by_id(id: u32) -> u32 {
-    let zt_world_mgr = read_zt_world_mgr_from_global();
+    let zt_world_mgr = crate::globals::globals().ztworldmgr();
     let entity_type_array_start = zt_world_mgr.entity_type_array_start;
     let entity_type_array_end = zt_world_mgr.entity_type_array_end;
 


### PR DESCRIPTION
Use casting and caching rather than reading the global structs from memory

## Description
<!--- Basic high level description -->

## Proposed Changes
<!--- Break the change down a bit -->

## Checklist
 - [ ] Docs <!--- Paste Link Here -->
 - [ ] Manually tested
 - [ ] Unit tests (where possible) <!--- Usually on relevant for parsing or utility functions -->
