### PR TITLE
Add tank/habitat placement logic and struct layout fixes

### DIFF
--- a/openzt-detour/src/generated.rs
+++ b/openzt-detour/src/generated.rs
@@ -183,7 +183,7 @@ pub mod bfentity {
 
     pub const INIT_AMBIENT_ANIMS: FunctionDef<unsafe extern "thiscall" fn(u32)> = FunctionDef{address: 0x00401115, function_type: PhantomData};
     pub const GET_TILE: FunctionDef<unsafe extern "thiscall" fn(u32) -> i32> = FunctionDef{address: 0x0040f8ac, function_type: PhantomData};
-    pub const GET_FOOTPRINT: FunctionDef<unsafe extern "thiscall" fn(u32, u32, bool) -> u32> = FunctionDef{address: 0x0040f916, function_type: PhantomData};
+    pub const GET_FOOTPRINT: FunctionDef<unsafe extern "thiscall" fn(*const u32, *const u32, bool) -> *const u32> = FunctionDef{address: 0x0040f916, function_type: PhantomData};
     pub const IS_WALKABLE: FunctionDef<unsafe extern "thiscall" fn(u32)> = FunctionDef{address: 0x0040fbbd, function_type: PhantomData};
     pub const DIR_TO_SET: FunctionDef<unsafe extern "thiscall" fn(u32, i32, u32, i32, u32) -> u32> = FunctionDef{address: 0x0040ff43, function_type: PhantomData};
     pub const VALIDATE_POSITION: FunctionDef<unsafe extern "thiscall" fn(u32, i8)> = FunctionDef{address: 0x0040ffc2, function_type: PhantomData};
@@ -202,7 +202,7 @@ pub mod bfentity {
     pub const SET_VISIBLE: FunctionDef<unsafe extern "thiscall" fn(u32, u8)> = FunctionDef{address: 0x0041e0f0, function_type: PhantomData};
     pub const IS_REMOVED_UNDO: FunctionDef<unsafe extern "thiscall" fn(u32)> = FunctionDef{address: 0x0041e1b5, function_type: PhantomData};
     pub const CREATE_NAME: FunctionDef<unsafe extern "thiscall" fn(u32)> = FunctionDef{address: 0x0041e84f, function_type: PhantomData};
-    pub const GET_BLOCKING_RECT: FunctionDef<unsafe extern "thiscall" fn(u32, u32) -> u32> = FunctionDef{address: 0x0042721a, function_type: PhantomData};
+    pub const GET_BLOCKING_RECT: FunctionDef<unsafe extern "thiscall" fn(*const u32, *const i32) -> *const u32> = FunctionDef{address: 0x0042721a, function_type: PhantomData};
     pub const GET_PLACEMENT_FOOTPRINT: FunctionDef<unsafe extern "thiscall" fn(u32)> = FunctionDef{address: 0x004272d4, function_type: PhantomData};
     pub const CLEAR_BS: FunctionDef<unsafe extern "thiscall" fn(u32) -> u32> = FunctionDef{address: 0x004274de, function_type: PhantomData};
     pub const CLEAR_QUEUE: FunctionDef<unsafe extern "thiscall" fn(u32)> = FunctionDef{address: 0x004275bb, function_type: PhantomData};
@@ -230,12 +230,12 @@ pub mod bfentity {
     pub const DRAW_UNDERWATER_SECTION: FunctionDef<unsafe extern "thiscall" fn(u32, u32, u32, u32, i32, u32)> = FunctionDef{address: 0x00496b99, function_type: PhantomData};
     pub const GET_HEIGHT: FunctionDef<unsafe extern "thiscall" fn(u32)> = FunctionDef{address: 0x00498d30, function_type: PhantomData};
     pub const SET_BSNEW: FunctionDef<unsafe extern "thiscall" fn(u32, u32, bool, u32) -> u32> = FunctionDef{address: 0x004a7e94, function_type: PhantomData};
-    pub const IS_ON_TILE: FunctionDef<unsafe extern "thiscall" fn(u32, u32) -> bool> = FunctionDef{address: 0x004e16f1, function_type: PhantomData};
+    pub const IS_ON_TILE: FunctionDef<unsafe extern "thiscall" fn(*const u32, *const u32) -> bool> = FunctionDef{address: 0x004e16f1, function_type: PhantomData};
     pub const DRAW_SELECTION_GRAPHIC: FunctionDef<unsafe extern "thiscall" fn(u32, i32, i32, u32)> = FunctionDef{address: 0x004ed85d, function_type: PhantomData};
     pub const SET_SELECTED: FunctionDef<unsafe extern "thiscall" fn(u32)> = FunctionDef{address: 0x004ee29a, function_type: PhantomData};
     pub const SEND_EVENT_0: FunctionDef<unsafe extern "thiscall" fn(u32)> = FunctionDef{address: 0x004f2bd5, function_type: PhantomData};
     pub const ADD_TO_MAP: FunctionDef<unsafe extern "thiscall" fn(u32)> = FunctionDef{address: 0x004f421f, function_type: PhantomData};
-    pub const GET_BLOCKING_RECT_VIRT_ZTPATH: FunctionDef<unsafe extern "thiscall" fn(u32, u32) -> u32> = FunctionDef{address: 0x004fbbee, function_type: PhantomData};
+    pub const GET_BLOCKING_RECT_VIRT_ZTPATH: FunctionDef<unsafe extern "thiscall" fn(*const u32, *const i32) -> *const u32> = FunctionDef{address: 0x004fbbee, function_type: PhantomData};
     pub const DESTROY_SELECTION_GRAPHICS: FunctionDef<unsafe extern "stdcall" fn()> = FunctionDef{address: 0x005028c5, function_type: PhantomData};
     pub const SNAP_TO_GRID: FunctionDef<unsafe extern "thiscall" fn(u32)> = FunctionDef{address: 0x00505763, function_type: PhantomData};
     pub const SEND_EVENT_1: FunctionDef<unsafe extern "thiscall" fn(u32, u32, u32, u32, u32, u32)> = FunctionDef{address: 0x0059df63, function_type: PhantomData};
@@ -420,7 +420,7 @@ pub mod bfmap {
     use super::*;
 
     pub const WORLD_TO_VIRTUAL_0: FunctionDef<unsafe extern "thiscall" fn(u32, u32, u32)> = FunctionDef{address: 0x0040f041, function_type: PhantomData};
-    pub const TILE_TO_WORLD: FunctionDef<unsafe extern "thiscall" fn(u32, u32, u32, u32) -> u32> = FunctionDef{address: 0x0040f26c, function_type: PhantomData};
+    pub const TILE_TO_WORLD: FunctionDef<unsafe extern "thiscall" fn(*const u32, *const i32, *const i32, *const i32) -> *const i32> = FunctionDef{address: 0x0040f26c, function_type: PhantomData};
     pub const GET_NEIGHBOR_0: FunctionDef<unsafe extern "thiscall" fn(u32, u32, u32) -> u32> = FunctionDef{address: 0x0040fa92, function_type: PhantomData};
     pub const GET_HEIGHT_ABOVE_TERRAIN: FunctionDef<unsafe extern "thiscall" fn(u32, u32) -> i32> = FunctionDef{address: 0x00410183, function_type: PhantomData};
     pub const GET_DIRECTION_0: FunctionDef<unsafe extern "stdcall" fn(i32, i32) -> i32> = FunctionDef{address: 0x00411654, function_type: PhantomData};
@@ -431,7 +431,7 @@ pub mod bfmap {
     pub const GET_NEIGHBORS: FunctionDef<unsafe extern "thiscall" fn(u32, u32, i32) -> u32> = FunctionDef{address: 0x004171a1, function_type: PhantomData};
     pub const GET_NEAREST_DIRECTION: FunctionDef<unsafe extern "fastcall" fn(u32, u32, i32, i32) -> u64> = FunctionDef{address: 0x00426c39, function_type: PhantomData};
     pub const GET_PROPER_DIRECTION: FunctionDef<unsafe extern "stdcall" fn(u32, i32, i32) -> u32> = FunctionDef{address: 0x0042b79a, function_type: PhantomData};
-    pub const GET_NEIGHBOR_1: FunctionDef<unsafe extern "thiscall" fn(u32, u32, u32) -> u32> = FunctionDef{address: 0x00432236, function_type: PhantomData};
+    pub const GET_NEIGHBOR_1: FunctionDef<unsafe extern "thiscall" fn(*const u32, *const u32, u32) -> u32> = FunctionDef{address: 0x00432236, function_type: PhantomData};
     pub const DRAW: FunctionDef<unsafe extern "thiscall" fn(u32, u32, u32, u32)> = FunctionDef{address: 0x00432dcd, function_type: PhantomData};
     pub const GET_TURNING_DIRECTION: FunctionDef<unsafe extern "stdcall" fn(i32, i32, u32) -> i32> = FunctionDef{address: 0x0043a28c, function_type: PhantomData};
     pub const WORLD_TO_VIRTUAL_1: FunctionDef<unsafe extern "thiscall" fn(u32)> = FunctionDef{address: 0x004402ed, function_type: PhantomData};
@@ -707,7 +707,7 @@ pub mod bftext {
 pub mod bftile {
     use super::*;
 
-    pub const GET_LOCAL_ELEVATION: FunctionDef<unsafe extern "thiscall" fn(u32, u32) -> i32> = FunctionDef{address: 0x0040f24d, function_type: PhantomData};
+    pub const GET_LOCAL_ELEVATION: FunctionDef<unsafe extern "thiscall" fn(*const u32, *const u32) -> i32> = FunctionDef{address: 0x0040f24d, function_type: PhantomData};
     pub const GET_CORNER_ELEVATION: FunctionDef<unsafe extern "thiscall" fn(u32, i32) -> i32> = FunctionDef{address: 0x0040f4f9, function_type: PhantomData};
     pub const IS_IN_ZOO: FunctionDef<unsafe extern "thiscall" fn(u32, i8) -> u32> = FunctionDef{address: 0x0040fb8d, function_type: PhantomData};
     pub const VALIDATE_POSITIONS: FunctionDef<unsafe extern "thiscall" fn(u32, u32, bool)> = FunctionDef{address: 0x0044a0bf, function_type: PhantomData};
@@ -1520,7 +1520,7 @@ pub mod ztanimal {
     use super::*;
 
     pub const CALC_HABITAT: FunctionDef<unsafe extern "thiscall" fn(u32)> = FunctionDef{address: 0x00410675, function_type: PhantomData};
-    pub const GET_FOOTPRINT: FunctionDef<unsafe extern "thiscall" fn(u32, u32, bool)> = FunctionDef{address: 0x00410803, function_type: PhantomData};
+    pub const GET_FOOTPRINT: FunctionDef<unsafe extern "thiscall" fn(*const u32, *const u32, bool) -> *const u32> = FunctionDef{address: 0x00410803, function_type: PhantomData};
     pub const GET_HABITAT_RATING: FunctionDef<unsafe extern "thiscall" fn(u32, u32) -> i32> = FunctionDef{address: 0x00411afd, function_type: PhantomData};
     pub const SET_HOME_HABITAT: FunctionDef<unsafe extern "thiscall" fn(u32, u32)> = FunctionDef{address: 0x00411b92, function_type: PhantomData};
     pub const GET_IDLE_ANIM: FunctionDef<unsafe extern "thiscall" fn(u32, i8) -> i32> = FunctionDef{address: 0x00413582, function_type: PhantomData};
@@ -2034,7 +2034,7 @@ pub mod zthabitat {
     pub const SET_DIRTY_CHARACTERISTICS: FunctionDef<unsafe extern "thiscall" fn(u32)> = FunctionDef{address: 0x0040f5a9, function_type: PhantomData};
     pub const IS_SHOW_TANK: FunctionDef<unsafe extern "thiscall" fn(u32) -> u32> = FunctionDef{address: 0x0040fba2, function_type: PhantomData};
     pub const GET_SHOW_INFO_ID: FunctionDef<unsafe extern "thiscall" fn(u32) -> u32> = FunctionDef{address: 0x0040fbc7, function_type: PhantomData};
-    pub const GET_GATE_TILE_IN: FunctionDef<unsafe extern "thiscall" fn(u32) -> u32> = FunctionDef{address: 0x00410349, function_type: PhantomData};
+    pub const GET_GATE_TILE_IN: FunctionDef<unsafe extern "thiscall" fn(*const u32) -> *const u32> = FunctionDef{address: 0x00410349, function_type: PhantomData};
     pub const GET_ALL_ANIMALS: FunctionDef<unsafe extern "thiscall" fn(u32, i8) -> u32> = FunctionDef{address: 0x00410def, function_type: PhantomData};
     pub const GET_GATE_TILE_OUT: FunctionDef<unsafe extern "thiscall" fn(u32) -> i32> = FunctionDef{address: 0x00411285, function_type: PhantomData};
     pub const GET_NUM_ANIMALS: FunctionDef<unsafe extern "thiscall" fn(u32, bool) -> i32> = FunctionDef{address: 0x00412167, function_type: PhantomData};
@@ -2275,7 +2275,7 @@ pub mod ztmapview {
     pub const COMMIT_TERRAFORM: FunctionDef<unsafe extern "thiscall" fn(u32, bool)> = FunctionDef{address: 0x004da19c, function_type: PhantomData};
     pub const UNDO_LAST_ACTION_0: FunctionDef<unsafe extern "thiscall" fn(u32)> = FunctionDef{address: 0x004de527, function_type: PhantomData};
     pub const SET_ENTITY_POSITION: FunctionDef<unsafe extern "thiscall" fn(u32, i32, u32, u32, u32)> = FunctionDef{address: 0x004ded90, function_type: PhantomData};
-    pub const CHECK_TANK_PLACEMENT: FunctionDef<unsafe extern "stdcall" fn(u32, u32, *mut u32) -> bool> = FunctionDef{address: 0x004df688, function_type: PhantomData};
+    pub const CHECK_TANK_PLACEMENT: FunctionDef<unsafe extern "stdcall" fn(*const u32, *const u32, *mut u32) -> bool> = FunctionDef{address: 0x004df688, function_type: PhantomData};
     pub const RENDER_1: FunctionDef<unsafe extern "stdcall" fn(i32)> = FunctionDef{address: 0x004df7e8, function_type: PhantomData};
     pub const SET_PLACE_GATE_MODE: FunctionDef<unsafe extern "thiscall" fn(u32, bool)> = FunctionDef{address: 0x004e1064, function_type: PhantomData};
     pub const FILL_CANVASES: FunctionDef<unsafe extern "thiscall" fn(u32)> = FunctionDef{address: 0x004ec8bf, function_type: PhantomData};
@@ -3133,7 +3133,7 @@ pub mod ztunit {
     use super::*;
 
     pub const VALIDATE_POSITION: FunctionDef<unsafe extern "thiscall" fn(u32, i8)> = FunctionDef{address: 0x004102b3, function_type: PhantomData};
-    pub const GET_FOOTPRINT: FunctionDef<unsafe extern "thiscall" fn(u32, u32, i8)> = FunctionDef{address: 0x0041070b, function_type: PhantomData};
+    pub const GET_FOOTPRINT: FunctionDef<unsafe extern "thiscall" fn(*const u32, *const u32, bool) -> *const u32> = FunctionDef{address: 0x0041070b, function_type: PhantomData};
     pub const IS_ON_WATER: FunctionDef<unsafe extern "fastcall" fn(u32) -> u32> = FunctionDef{address: 0x00410fe0, function_type: PhantomData};
     pub const GET_PREDATOR_UNIT: FunctionDef<unsafe extern "thiscall" fn(u32) -> i32> = FunctionDef{address: 0x00412259, function_type: PhantomData};
     pub const ADD_TO_MAP: FunctionDef<unsafe extern "thiscall" fn(u32) -> u32> = FunctionDef{address: 0x00412c70, function_type: PhantomData};

--- a/openzt.bat
+++ b/openzt.bat
@@ -330,8 +330,17 @@ REM Test Function
 REM ============================================================
 
 :test
+SHIFT
+SET TEST_ARGS=
+:test_args_loop
+IF "%~1"=="" GOTO run_test
+SET TEST_ARGS=!TEST_ARGS! %1
+SHIFT
+GOTO test_args_loop
+
+:run_test
 echo Running cargo test on openzt...
-cargo test --manifest-path openzt/Cargo.toml --target i686-pc-windows-msvc
+cargo test --manifest-path openzt/Cargo.toml --target i686-pc-windows-msvc !TEST_ARGS!
 
 IF !errorlevel! NEQ 0 (
     echo.
@@ -381,6 +390,7 @@ echo   openzt.bat run --test                Build test DLL and launch game
 echo   openzt.bat check                     Run cargo check on openzt
 echo   openzt.bat clippy                    Run cargo clippy on openzt
 echo   openzt.bat test                      Run cargo test on openzt
+echo   openzt.bat test -- --nocapture        Run cargo test, forwarding extra args to cargo
 echo   openzt.bat integration-tests         Run integration tests (builds release, displays results)
 echo   openzt.bat docs                      Generate and open docs
 echo   openzt.bat console                   Open interactive Lua console

--- a/openzt/src/bfentitytype.rs
+++ b/openzt/src/bfentitytype.rs
@@ -8,6 +8,7 @@ use num_enum::FromPrimitive;
 use tracing::info;
 
 use crate::util::ZTBoundedString;
+use crate::ztworldmgr::IVec3;
 use crate::{
     command_console::CommandError,
     expansions::is_member,
@@ -73,14 +74,15 @@ pub struct BFEntityType {
     pub uses_placement_cube: bool,    // 0x06E
     pub show: bool,                   // 0x06F
     pub hit_threshold: u32,           // 0x070
-    pub avoid_edges: bool,            // 0x074
+    pub avoid_edges: u32,             // 0x074 (How close to the edge of a tank can an entity be placed)
     // TODO: Add to display impl and test these bits, if they work replace usage of ZTEntityType with BFEntityType
-    pad8: [u8; 0x080 - 0x075],        // ----------------------- padding: 11 bytes
+    pad8: [u8; 0x080 - 0x078],        // ----------------------- padding: 8 bytes
     pub bf_config_file_ptr: u32,      // 0x080
     pad9: [u8; 0x098 - 0x084],        // ----------------------- padding: 20 bytes
     pub zt_type: ZTBoundedString,     // 0x098
     pub zt_sub_type: ZTBoundedString, // 0x0A4
     pad10: [u8; 0x0B4 - 0x0A8],       // ----------------------- padding: 4 bytes
+    // pad10: [u8; 0x0B4 - 0x0B0],       // ----------------------- padding: 4 bytes
     pub footprintx: i32,              // 0x0B4
     pub footprinty: i32,              // 0x0B8
     pub footprintz: i32,              // 0x0BC
@@ -88,7 +90,7 @@ pub struct BFEntityType {
     pub placement_footprinty: i32,    // 0x0C4
     pub placement_footprintz: i32,    // 0x0C8
     pub available_at_startup: bool,   // 0x0CC
-    pad11: [u8; 0x100 - 0x0CD],       // ----------------------- padding: 35 bytes
+    pad11: [u8; 0x100 - 0x0CD],       // ----------------------- padding: 51 bytes
 }
 
 impl BFEntityType {
@@ -182,6 +184,7 @@ impl EntityType for BFEntityType {
 // Does BF/ZTUnitType also load purchase cost, name id etc?
 #[derive(Debug, Getters, Setters, FieldAccessorAsString)]
 #[repr(C)]
+#[get = "pub"]
 pub struct ZTSceneryType {
     #[deref_field]
     pub bfentitytype: BFEntityType, // bytes: 0x100 - 0x000 = 0x100 = 256 bytes
@@ -215,7 +218,7 @@ pub struct ZTSceneryType {
     pub uses_tree_rubble: bool,      // 0x139
     pub forces_scenery_rubble: bool, // 0x13A
     pub blocks_los: bool,            // 0x13B
-    pad7: [u8; 0x168 - 0x13C],       // ----------------------- padding: 51 bytes
+    pad7: [u8; 0x168 - 0x13C],       // ----------------------- padding: 44 bytes
 }
 
 impl ZTSceneryType {
@@ -756,12 +759,17 @@ pub struct BFUnitType {
     pad0: [u8; 0x114 - 0x112],  // ----------------------- padding: 2 bytes
     pub min_height: u32,        // 0x114 <--- unsure if accurate
     pub max_height: u32,        // 0x118 <--- unsure if accurate
+    pad1: [u8; 0x12C - 0x11C],        // ----------------------- padding: 16 bytes
+    pub purchase_cost: f32,           // 0x12C
+    pub name_id: i32,                 // 0x130
+    pub help_id: i32,                 // 0x134
+    pad2: [u8; 0x144 - 0x138],        // ----------------------- padding: 16 bytes
 }
 
 impl EntityType for BFUnitType {
     fn print_config_integers(&self) -> String {
         format!(
-            "{}\ncSlowRate: {}\ncMediumRate: {}\ncFastRate: {}\ncSlowAnimSpeed: {}\ncMediumAnimSpeed: {}\ncFastAnimSpeed: {}\ncMinHeight: {}\ncMaxHeight: {}\n",
+            "{}\ncSlowRate: {}\ncMediumRate: {}\ncFastRate: {}\ncSlowAnimSpeed: {}\ncMediumAnimSpeed: {}\ncFastAnimSpeed: {}\ncMinHeight: {}\ncMaxHeight: {}\ncPurchaseCost: {}\ncNameID: {}\ncHelpID: {}\n",
             self.bfentitytype.print_config_integers(),
             self.slow_rate,
             self.medium_rate,
@@ -771,6 +779,9 @@ impl EntityType for BFUnitType {
             self.fast_anim_speed,
             self.min_height,
             self.max_height,
+            self.purchase_cost,
+            self.name_id,
+            self.help_id,
         )
     }
 
@@ -800,23 +811,18 @@ impl Deref for BFUnitType {
 #[repr(C)]
 pub struct ZTUnitType {
     #[deref_field]
-    pub bfunit_type: BFUnitType, // bytes: 0x11C - 0x100 = 0x1C = 28 bytes
-    pad0: [u8; 0x12C - 0x11C],        // ----------------------- padding: 16 bytes
-    pub purchase_cost: f32,           // 0x12C
-    pub name_id: i32,                 // 0x130
-    pub help_id: i32,                 // 0x134
-    pad1: [u8; 0x150 - 0x138],        // ----------------------- padding: 24 bytes
+    pub bfunit_type: BFUnitType, // bytes: 0x144 - 0x100 = 0x44 = 68 bytes
+    pad1: [u8; 0x150 - 0x144],        // ----------------------- padding: 24 bytes
     pub map_footprint: i32,           // 0x150
     pub slow_anim_speed_water: u16,   // 0x154
     pub medium_anim_speed_water: u16, // 0x156
     pub fast_anim_speed_water: u16,   // 0x158
-    pad2: [u8; 0x17C - 0x15C],        // ----------------------- padding: 32 bytes
+    pad2: [u8; 0x17C - 0x15A],        // ----------------------- padding: 32 bytes
     // pub list_image_name: String,    // 0x168 TODO: fix offset for string getters in unittype
     pub swims: bool,               // 0x17C
     pub surface: bool,             // 0x17D
     pub underwater: bool,          // 0x17E
     pub only_underwater: bool,     // 0x17F
-    pad3: [u8; 0x180 - 0x17F],     // ----------------------- padding: 1 byte
     pub skip_trick_happiness: u32, // 0x180 TODO: potentially not accurate
     pub skip_trick_chance: i32,    // 0x184
 }
@@ -830,11 +836,8 @@ impl ZTUnitType {
 
 impl EntityType for ZTUnitType {
     fn print_config_integers(&self) -> String {
-        format!("{}\ncPurchaseCost: {}\ncNameID: {}\ncHelpID: {}\ncMapFootprint: {}\ncSlowAnimSpeedWater: {}\ncMediumAnimSpeedWater: {}\ncFastAnimSpeedWater: {}\ncSwims: {}\ncSurface: {}\ncUnderwater: {}\ncOnlyUnderwater: {}\ncSkipTrickHappiness: {}\ncSkipTrickChance: {}\n",
+        format!("{}\ncMapFootprint: {}\ncSlowAnimSpeedWater: {}\ncMediumAnimSpeedWater: {}\ncFastAnimSpeedWater: {}\ncSwims: {}\ncSurface: {}\ncUnderwater: {}\ncOnlyUnderwater: {}\ncSkipTrickHappiness: {}\ncSkipTrickChance: {}\n",
                 self.bfunit_type.print_config_integers(),
-                self.purchase_cost,
-                self.name_id,
-                self.help_id,
                 self.map_footprint,
                 self.slow_anim_speed_water,
                 self.medium_anim_speed_water,
@@ -1031,9 +1034,7 @@ pub struct ZTAnimalType {
     #[deref_field]
     pub ztunit_type: ZTUnitType, // bytes: 0x188 - 0x100 = 0x88 = 136 bytes
     pad00: [u8; 0x1D8 - 0x188],         // ----------------------- padding: 72 bytes
-    pub box_footprint_x: i32,           // 0x1D8
-    pub box_footprint_y: i32,           // 0x1DC
-    pub box_footprint_z: i32,           // 0x1E0
+    pub box_footprint: IVec3,           // 0x1D8
     pub family: i32,                    // 0x1E4
     pub genus: i32,                     // 0x1E8
     pad01: [u8; 0x1F0 - 0x1EC],         // ----------------------- padding: 4 bytes
@@ -1136,15 +1137,17 @@ pub struct ZTAnimalType {
     pub need_shelter: bool,       // 0x3D2
     pub need_toys: bool,          // 0x3D3
     pub babies_attack: bool,      // 0x3D4
+    pad19: [u8; 0x410 - 0x3D8],   // ----------------------- padding: 8 bytes
+    pub egg_footprint: IVec3,         // 0x410
 }
 
 impl EntityType for ZTAnimalType {
     fn print_config_integers(&self) -> String {
-        format!("{}\ncBoxFootprintX: {}\ncBoxFootprintY: {}\ncBoxFootprintZ: {}\ncFamily: {}\ncGenus: {}\ncHabitat: {}\ncLocation: {}\ncEra: {}\ncBreathThreshold: {}\ncBreathIncrement: {}\ncHungerThreshold: {}\ncHungryHealthChange: {}\ncHungerIncrement: {}\ncFoodUnitValue: {}\ncKeeperFoodUnitsEaten: {}\ncNeededFood: {}\ncNoFoodChange: {}\ncInitialHappiness: {}\ncMaxHits: {}\ncPctHits: {}\ncMaxEnergy: {}\ncMaxDirty: {}\ncMinDirty: {}\ncSickChange: {}\ncOtherAnimalSickChange: {}\ncSickChance: {}\ncSickRandomChance: {}\ncCrowd: {}\ncCrowdHappinessChange: {}\ncZapHappinessChange: {}\ncCaptivity: {}\ncReproductionChance: {}\ncReproductionInterval: {}\ncMatingType: {}\ncOffspring: {}\ncKeeperFrequency: {}\ncNotEnoughKeepersChange: {}\ncSocial: {}\ncHabitatSize: {}\ncNumberAnimalsMin: {}\ncNumberAnimalsMax: {}\ncNumberMinChange: {}\ncNumberMaxChange: {}\ncHabitatPreference: {}\ncBabyBornChange: {}\ncEnergyIncrement: {}\ncEnergyThreshold: {}\ncDirtyIncrement: {}\ncDirtyThreshold: {}\ncSickTime: {}\ncBabyToAdult: {}\ncOtherFood: {}\ncTreePref: {}\ncRockPref: {}\ncSpacePref: {}\ncElevationPref: {}\ncDepthMin: {}\ncDepthMax: {}\ncDepthChange: {}\ncSalinityChange: {}\ncSalinityHealthChange: {}\ncHappyReproduceThreshold: {}\ncBuildingUseChance: {}\ncNoMateChange: {}\ncTimeDeath: {}\ncDeathChance: {}\ncDirtChance: {}\ncWaterNeeded: {}\ncUnderwaterNeeded: {}\ncLandNeeded: {}\ncEnterWaterChance: {}\ncEnterTankChance: {}\ncEnterLandChance: {}\ncDrinkWaterChance: {}\ncChaseAnimalChance: {}\ncClimbsCliffs: {}\ncBashStrength: {}\ncAttractiveness: {}\ncKeeperFoodType: {}\ncIsClimber: {}\ncIsJumper: {}\ncSmallZoodoo: {}\ncDinoZoodoo: {}\ncGiantZoodoo: {}\ncIsSpecialAnimal: {}\ncNeedShelter: {}\ncNeedToys: {}\ncBabiesAttack: {}\n",
+        format!("{}\ncBoxFootprintX: {}\ncBoxFootprintY: {}\ncBoxFootprintZ: {}\ncFamily: {}\ncGenus: {}\ncHabitat: {}\ncLocation: {}\ncEra: {}\ncBreathThreshold: {}\ncBreathIncrement: {}\ncHungerThreshold: {}\ncHungryHealthChange: {}\ncHungerIncrement: {}\ncFoodUnitValue: {}\ncKeeperFoodUnitsEaten: {}\ncNeededFood: {}\ncNoFoodChange: {}\ncInitialHappiness: {}\ncMaxHits: {}\ncPctHits: {}\ncMaxEnergy: {}\ncMaxDirty: {}\ncMinDirty: {}\ncSickChange: {}\ncOtherAnimalSickChange: {}\ncSickChance: {}\ncSickRandomChance: {}\ncCrowd: {}\ncCrowdHappinessChange: {}\ncZapHappinessChange: {}\ncCaptivity: {}\ncReproductionChance: {}\ncReproductionInterval: {}\ncMatingType: {}\ncOffspring: {}\ncKeeperFrequency: {}\ncNotEnoughKeepersChange: {}\ncSocial: {}\ncHabitatSize: {}\ncNumberAnimalsMin: {}\ncNumberAnimalsMax: {}\ncNumberMinChange: {}\ncNumberMaxChange: {}\ncHabitatPreference: {}\ncBabyBornChange: {}\ncEnergyIncrement: {}\ncEnergyThreshold: {}\ncDirtyIncrement: {}\ncDirtyThreshold: {}\ncSickTime: {}\ncBabyToAdult: {}\ncOtherFood: {}\ncTreePref: {}\ncRockPref: {}\ncSpacePref: {}\ncElevationPref: {}\ncDepthMin: {}\ncDepthMax: {}\ncDepthChange: {}\ncSalinityChange: {}\ncSalinityHealthChange: {}\ncHappyReproduceThreshold: {}\ncBuildingUseChance: {}\ncNoMateChange: {}\ncTimeDeath: {}\ncDeathChance: {}\ncDirtChance: {}\ncWaterNeeded: {}\ncUnderwaterNeeded: {}\ncLandNeeded: {}\ncEnterWaterChance: {}\ncEnterTankChance: {}\ncEnterLandChance: {}\ncDrinkWaterChance: {}\ncChaseAnimalChance: {}\ncClimbsCliffs: {}\ncBashStrength: {}\ncAttractiveness: {}\ncKeeperFoodType: {}\ncIsClimber: {}\ncIsJumper: {}\ncSmallZoodoo: {}\ncDinoZoodoo: {}\ncGiantZoodoo: {}\ncIsSpecialAnimal: {}\ncNeedShelter: {}\ncNeedToys: {}\ncBabiesAttack: {}\n EggFootprintX: {}\ncEggFootprintY: {}\ncEggFootprintZ: {}\n",
         self.ztunit_type.print_config_integers(),
-        self.box_footprint_x,
-        self.box_footprint_y,
-        self.box_footprint_z,
+        self.box_footprint.x,
+        self.box_footprint.y,
+        self.box_footprint.z,
         self.family,
         self.genus,
         self.habitat,
@@ -1230,6 +1233,9 @@ impl EntityType for ZTAnimalType {
         self.need_shelter as i32,
         self.need_toys as i32,
         self.babies_attack as i32,
+        self.egg_footprint.x,
+        self.egg_footprint.y,
+        self.egg_footprint.z,
         )
     }
 
@@ -1821,6 +1827,36 @@ pub enum ZTEntityTypeClass {
     BFEntity = 0x62e28c,
     #[num_enum(default)]
     Unknown = 0x0,
+}
+
+impl std::str::FromStr for ZTEntityTypeClass {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "animal" => Ok(ZTEntityTypeClass::Animal),
+            "ambient" => Ok(ZTEntityTypeClass::Ambient),
+            "guest" => Ok(ZTEntityTypeClass::Guest),
+            "fence" => Ok(ZTEntityTypeClass::Fence),
+            "tourguide" => Ok(ZTEntityTypeClass::TourGuide),
+            "building" => Ok(ZTEntityTypeClass::Building),
+            "scenery" => Ok(ZTEntityTypeClass::Scenery),
+            "food" => Ok(ZTEntityTypeClass::Food),
+            "tankfilter" => Ok(ZTEntityTypeClass::TankFilter),
+            "path" => Ok(ZTEntityTypeClass::Path),
+            "rubble" => Ok(ZTEntityTypeClass::Rubble),
+            "tankwall" => Ok(ZTEntityTypeClass::TankWall),
+            "keeper" => Ok(ZTEntityTypeClass::Keeper),
+            "maintenanceworker" => Ok(ZTEntityTypeClass::MaintenanceWorker),
+            "drt" => Ok(ZTEntityTypeClass::Drt),
+            "bfoverlay" => Ok(ZTEntityTypeClass::BFOverlay),
+            "bfunit" => Ok(ZTEntityTypeClass::BFUnit),
+            "ztunit" => Ok(ZTEntityTypeClass::ZTUnit),
+            "staff" => Ok(ZTEntityTypeClass::Staff),
+            "bfentity" => Ok(ZTEntityTypeClass::BFEntity),
+            _ => Err(format!("Unknown entity type class: {}", s)),
+        }
+    }
 }
 
 pub fn zt_entity_type_class_is(original_class: &ZTEntityTypeClass, class: &ZTEntityTypeClass) -> bool {

--- a/openzt/src/bfentitytype.rs
+++ b/openzt/src/bfentitytype.rs
@@ -80,9 +80,8 @@ pub struct BFEntityType {
     pub bf_config_file_ptr: u32,      // 0x080
     pad9: [u8; 0x098 - 0x084],        // ----------------------- padding: 20 bytes
     pub zt_type: ZTBoundedString,     // 0x098
-    pub zt_sub_type: ZTBoundedString, // 0x0A4
-    pad10: [u8; 0x0B4 - 0x0A8],       // ----------------------- padding: 4 bytes
-    // pad10: [u8; 0x0B4 - 0x0B0],       // ----------------------- padding: 4 bytes
+    pub zt_sub_type: ZTBoundedString, // 0x0A0
+    pad10: [u8; 0x0B4 - 0x0A8],       // ----------------------- padding: 12 bytes
     pub footprintx: i32,              // 0x0B4
     pub footprinty: i32,              // 0x0B8
     pub footprintz: i32,              // 0x0BC
@@ -92,6 +91,8 @@ pub struct BFEntityType {
     pub available_at_startup: bool,   // 0x0CC
     pad11: [u8; 0x100 - 0x0CD],       // ----------------------- padding: 51 bytes
 }
+
+const _: () = assert!(std::mem::size_of::<BFEntityType>() == 0x100);
 
 impl BFEntityType {
     // returns the codename of the entity type
@@ -766,6 +767,8 @@ pub struct BFUnitType {
     pad2: [u8; 0x144 - 0x138],        // ----------------------- padding: 16 bytes
 }
 
+const _: () = assert!(std::mem::size_of::<BFUnitType>() == 0x144);
+
 impl EntityType for BFUnitType {
     fn print_config_integers(&self) -> String {
         format!(
@@ -827,7 +830,29 @@ pub struct ZTUnitType {
     pub skip_trick_chance: i32,    // 0x184
 }
 
+const _: () = assert!(std::mem::size_of::<ZTUnitType>() == 0x188);
+
 impl ZTUnitType {
+    /// Confirmed real vtable VA for `ZTUnitType` in zoo.exe (see `private/docs/vtables/ZTUnitType.md`).
+    /// `ZTUnitType` overrides `BFEntityType`'s `+0x1c` slot with a different function (confirmed by
+    /// the vtable diff docs), so fixtures must use this class's own vtable, not `BFEntityType`'s
+    /// - see `ztunit-ztanimal-footprint-crash-investigation.md`.
+    const VTABLE_PTR: u32 = 0x0062e404;
+
+    /// Test-only fixture: a zero-filled `ZTUnitType` with a real vtable pointer, needed because
+    /// `ZTUnit::getFootprint` virtually dispatches through `entity_type`'s vtable (not its own) in
+    /// its `use_map_footprint=true` branch. `mem::zeroed()` is otherwise safe: every other field is
+    /// an integer/bool/byte-array.
+    pub fn new_for_test(footprint: IVec3, map_footprint: i32) -> Self {
+        let mut entity_type: ZTUnitType = unsafe { std::mem::zeroed() };
+        entity_type.bfunit_type.bfentitytype.vtable = Self::VTABLE_PTR;
+        entity_type.bfunit_type.bfentitytype.footprintx = footprint.x;
+        entity_type.bfunit_type.bfentitytype.footprinty = footprint.y;
+        entity_type.bfunit_type.bfentitytype.footprintz = footprint.z;
+        entity_type.map_footprint = map_footprint;
+        entity_type
+    }
+
     pub fn get_list_name(&self) -> String {
         let obj_ptr = self as *const ZTUnitType as u32;
         get_string_from_memory(get_from_memory::<u32>(obj_ptr + 0x168))
@@ -1141,6 +1166,8 @@ pub struct ZTAnimalType {
     pub egg_footprint: IVec3,         // 0x410
 }
 
+const _: () = assert!(std::mem::size_of::<ZTAnimalType>() == 0x41c);
+
 impl EntityType for ZTAnimalType {
     fn print_config_integers(&self) -> String {
         format!("{}\ncBoxFootprintX: {}\ncBoxFootprintY: {}\ncBoxFootprintZ: {}\ncFamily: {}\ncGenus: {}\ncHabitat: {}\ncLocation: {}\ncEra: {}\ncBreathThreshold: {}\ncBreathIncrement: {}\ncHungerThreshold: {}\ncHungryHealthChange: {}\ncHungerIncrement: {}\ncFoodUnitValue: {}\ncKeeperFoodUnitsEaten: {}\ncNeededFood: {}\ncNoFoodChange: {}\ncInitialHappiness: {}\ncMaxHits: {}\ncPctHits: {}\ncMaxEnergy: {}\ncMaxDirty: {}\ncMinDirty: {}\ncSickChange: {}\ncOtherAnimalSickChange: {}\ncSickChance: {}\ncSickRandomChance: {}\ncCrowd: {}\ncCrowdHappinessChange: {}\ncZapHappinessChange: {}\ncCaptivity: {}\ncReproductionChance: {}\ncReproductionInterval: {}\ncMatingType: {}\ncOffspring: {}\ncKeeperFrequency: {}\ncNotEnoughKeepersChange: {}\ncSocial: {}\ncHabitatSize: {}\ncNumberAnimalsMin: {}\ncNumberAnimalsMax: {}\ncNumberMinChange: {}\ncNumberMaxChange: {}\ncHabitatPreference: {}\ncBabyBornChange: {}\ncEnergyIncrement: {}\ncEnergyThreshold: {}\ncDirtyIncrement: {}\ncDirtyThreshold: {}\ncSickTime: {}\ncBabyToAdult: {}\ncOtherFood: {}\ncTreePref: {}\ncRockPref: {}\ncSpacePref: {}\ncElevationPref: {}\ncDepthMin: {}\ncDepthMax: {}\ncDepthChange: {}\ncSalinityChange: {}\ncSalinityHealthChange: {}\ncHappyReproduceThreshold: {}\ncBuildingUseChance: {}\ncNoMateChange: {}\ncTimeDeath: {}\ncDeathChance: {}\ncDirtChance: {}\ncWaterNeeded: {}\ncUnderwaterNeeded: {}\ncLandNeeded: {}\ncEnterWaterChance: {}\ncEnterTankChance: {}\ncEnterLandChance: {}\ncDrinkWaterChance: {}\ncChaseAnimalChance: {}\ncClimbsCliffs: {}\ncBashStrength: {}\ncAttractiveness: {}\ncKeeperFoodType: {}\ncIsClimber: {}\ncIsJumper: {}\ncSmallZoodoo: {}\ncDinoZoodoo: {}\ncGiantZoodoo: {}\ncIsSpecialAnimal: {}\ncNeedShelter: {}\ncNeedToys: {}\ncBabiesAttack: {}\n EggFootprintX: {}\ncEggFootprintY: {}\ncEggFootprintZ: {}\n",
@@ -1249,6 +1276,25 @@ impl EntityType for ZTAnimalType {
 
     fn print_config_details(&self) -> String {
         self.ztunit_type.print_config_details()
+    }
+}
+
+impl ZTAnimalType {
+    /// Confirmed real vtable VA for `ZTAnimalType` in zoo.exe (see `private/docs/vtables/ZTAnimalType.md`).
+    /// See `ZTUnitType::VTABLE_PTR` for why the type's own vtable is required, not `BFEntityType`'s.
+    const VTABLE_PTR: u32 = 0x00630268;
+
+    /// Test-only fixture, see `ZTUnitType::new_for_test`.
+    pub fn new_for_test(footprint: IVec3, map_footprint: i32, box_footprint: IVec3, egg_footprint: IVec3) -> Self {
+        let mut entity_type: ZTAnimalType = unsafe { std::mem::zeroed() };
+        entity_type.ztunit_type.bfunit_type.bfentitytype.vtable = Self::VTABLE_PTR;
+        entity_type.ztunit_type.bfunit_type.bfentitytype.footprintx = footprint.x;
+        entity_type.ztunit_type.bfunit_type.bfentitytype.footprinty = footprint.y;
+        entity_type.ztunit_type.bfunit_type.bfentitytype.footprintz = footprint.z;
+        entity_type.ztunit_type.map_footprint = map_footprint;
+        entity_type.box_footprint = box_footprint;
+        entity_type.egg_footprint = egg_footprint;
+        entity_type
     }
 }
 
@@ -2021,5 +2067,54 @@ pub fn command_make_sel(args: Vec<&str>) -> Result<String, CommandError> {
         }
         entity_type.selectable = true;
         Ok(format!("Entity type {} is now selectable", entity_type.bfentitytype.get_type_name()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Explicit list (not derived from the enum) so it visibly needs updating when a
+    // variant is added and the match arm in `FromStr` is forgotten.
+    const ZT_ENTITY_TYPE_CLASS_CASES: &[(ZTEntityTypeClass, &str)] = &[
+        (ZTEntityTypeClass::Animal, "animal"),
+        (ZTEntityTypeClass::Ambient, "ambient"),
+        (ZTEntityTypeClass::Guest, "guest"),
+        (ZTEntityTypeClass::Fence, "fence"),
+        (ZTEntityTypeClass::TourGuide, "tourguide"),
+        (ZTEntityTypeClass::Building, "building"),
+        (ZTEntityTypeClass::Scenery, "scenery"),
+        (ZTEntityTypeClass::Food, "food"),
+        (ZTEntityTypeClass::TankFilter, "tankfilter"),
+        (ZTEntityTypeClass::Path, "path"),
+        (ZTEntityTypeClass::Rubble, "rubble"),
+        (ZTEntityTypeClass::TankWall, "tankwall"),
+        (ZTEntityTypeClass::Keeper, "keeper"),
+        (ZTEntityTypeClass::MaintenanceWorker, "maintenanceworker"),
+        (ZTEntityTypeClass::Drt, "drt"),
+        (ZTEntityTypeClass::BFOverlay, "bfoverlay"),
+        (ZTEntityTypeClass::BFUnit, "bfunit"),
+        (ZTEntityTypeClass::ZTUnit, "ztunit"),
+        (ZTEntityTypeClass::Staff, "staff"),
+        (ZTEntityTypeClass::BFEntity, "bfentity"),
+    ];
+
+    #[test]
+    fn test_zt_entity_type_class_from_str_round_trip() {
+        for (variant, s) in ZT_ENTITY_TYPE_CLASS_CASES {
+            assert_eq!(s.parse::<ZTEntityTypeClass>().unwrap(), *variant, "failed to parse '{}'", s);
+        }
+    }
+
+    #[test]
+    fn test_zt_entity_type_class_from_str_case_insensitive() {
+        assert_eq!("Animal".parse::<ZTEntityTypeClass>().unwrap(), ZTEntityTypeClass::Animal);
+        assert_eq!("ANIMAL".parse::<ZTEntityTypeClass>().unwrap(), ZTEntityTypeClass::Animal);
+        assert_eq!("aNiMaL".parse::<ZTEntityTypeClass>().unwrap(), ZTEntityTypeClass::Animal);
+    }
+
+    #[test]
+    fn test_zt_entity_type_class_from_str_unknown_is_err() {
+        assert!("not_a_real_entity_type_class".parse::<ZTEntityTypeClass>().is_err());
     }
 }

--- a/openzt/src/integration_tests/mod.rs
+++ b/openzt/src/integration_tests/mod.rs
@@ -95,8 +95,14 @@ macro_rules! integration_tests {
 pub fn init() {
     #[cfg(target_os = "windows")]
     {
+        #[cfg(feature = "tui")]
+        let tui_config: Option<&crate::tui_console::TuiConfig> = None;
+        #[cfg(not(feature = "tui"))]
+        let tui_config = None;
+
         if let Err(e) = crate::logging::init_with_console(
-            &crate::logging::LoggingConfig::default()
+            &crate::logging::LoggingConfig::default(),
+            tui_config,
         ) {
             eprintln!("Failed to initialize logging: {}", e);
         }

--- a/openzt/src/reimplementation_tests/mod.rs
+++ b/openzt/src/reimplementation_tests/mod.rs
@@ -98,7 +98,7 @@ mod detour_zoo_main {
                 let tile = BFTile::new(pos, unknown_byte_2);
                 let reimplemented_result = tile.get_local_elevation(pos);
 
-                let result = GET_LOCAL_ELEVATION.original()(&raw const tile as u32, &raw const pos as u32);
+                let result = GET_LOCAL_ELEVATION.original()(&raw const tile as *const u32, &raw const pos as *const u32);
                 assert_eq!(
                     result,
                     reimplemented_result + 1,

--- a/openzt/src/reimplementation_tests/mod.rs
+++ b/openzt/src/reimplementation_tests/mod.rs
@@ -101,11 +101,13 @@ mod detour_zoo_main {
                 let result = GET_LOCAL_ELEVATION.original()(&raw const tile as *const u32, &raw const pos as *const u32);
                 assert_eq!(
                     result,
-                    reimplemented_result + 1,
-                    "Failed for pos: {:?}, tile: {:?}, unknown_byte_2: {}",
+                    reimplemented_result,
+                    "Failed for pos: {:?}, tile: {:?}, unknown_byte_2: {}, real: {}, reimplemented: {}",
                     pos,
                     tile,
-                    unknown_byte_2
+                    unknown_byte_2,
+                    result,
+                    reimplemented_result
                 );
                 Ok(())
             }) {
@@ -115,7 +117,11 @@ mod detour_zoo_main {
                 Err(e) => {
                     error!("Proptest failed: {:?}", e);
                     if let proptest::test_runner::TestError::Fail(r, (x, y)) = e {
-                        let failure_line = format!("unknown_byte_2: {}, x: {}, y: {}\n", unknown_byte_2, x, y);
+                        let pos = IVec3::new(x, y, 0);
+                        let tile = BFTile::new(pos, unknown_byte_2);
+                        let reimplemented_result = tile.get_local_elevation(pos);
+                        let result = GET_LOCAL_ELEVATION.original()(&raw const tile as *const u32, &raw const pos as *const u32);
+                        let failure_line = format!("unknown_byte_2: {}, x: {}, y: {}, real: {}, reimplemented: {}\n", unknown_byte_2, x, y, result, reimplemented_result);
 
                         if let Some(ref mut log_file) = failure_log {
                             if let Err(write_err) = log_file.write_all(failure_line.as_bytes()) {

--- a/openzt/src/reimplementation_tests/mod.rs
+++ b/openzt/src/reimplementation_tests/mod.rs
@@ -11,8 +11,14 @@ use crate::detour_mod;
 pub fn init() {
     #[cfg(target_os = "windows")]
     {
+        #[cfg(feature = "tui")]
+        let tui_config: Option<&crate::tui_console::TuiConfig> = None;
+        #[cfg(not(feature = "tui"))]
+        let tui_config = None;
+
         if let Err(e) = crate::logging::init_with_console(
-            &crate::logging::LoggingConfig::default()
+            &crate::logging::LoggingConfig::default(),
+            tui_config,
         ) {
             eprintln!("Failed to initialize logging: {}", e);
         }
@@ -57,11 +63,19 @@ mod detour_zoo_main {
 
     #[cfg(target_os = "windows")]
     use openzt_detour::generated::bfapp::LOAD_LANG_DLLS;
+    use openzt_detour::generated::bfentity::GET_FOOTPRINT as BFENTITY_GET_FOOTPRINT;
     use openzt_detour::generated::bftile::GET_LOCAL_ELEVATION;
+    use openzt_detour::generated::ztanimal::GET_FOOTPRINT as ZTANIMAL_GET_FOOTPRINT;
+    use openzt_detour::generated::ztunit::GET_FOOTPRINT as ZTUNIT_GET_FOOTPRINT;
+    use openzt_detour::FunctionDef;
     use proptest::prelude::ProptestConfig;
     use tracing::{error, info};
 
-    use crate::{ztmapview::BFTile, ztworldmgr::IVec3};
+    use crate::{
+        bfentitytype::{BFEntityType, ZTAnimalType, ZTUnitType},
+        ztmapview::BFTile,
+        ztworldmgr::{BFEntity, IVec3, ZTAnimal, ZTUnit},
+    };
 
     // TODO: Fix this so it works with a crate/mod prefix
     #[detour(LOAD_LANG_DLLS)]
@@ -148,6 +162,221 @@ mod detour_zoo_main {
                 }
             }
         }
+
+        fail_flag |= run_bfentity_get_footprint_tests(&mut failure_log);
+        fail_flag |= run_ztunit_get_footprint_tests(&mut failure_log);
+        fail_flag |= run_ztanimal_get_footprint_tests(&mut failure_log);
+
+        if fail_flag {
+            error!("Proptest failed for some cases, check the failure log at: {}", failure_log_path);
+            std::process::exit(1);
+        }
         std::process::exit(0);
+    }
+
+    fn write_success_line(failure_log: &mut Option<std::fs::File>, test_name: &str) {
+        let success_line = format!("Test Passed {}\n", test_name);
+        if let Some(log_file) = failure_log {
+            if let Err(write_err) = log_file.write_all(success_line.as_bytes()) {
+                error!("Failed to write to failure log: {}", write_err);
+            }
+        }
+    }
+
+    /// Calls the real GET_FOOTPRINT function at `entity_ptr` and reads the `IVec3` it writes back.
+    fn call_original_get_footprint(
+        original: FunctionDef<unsafe extern "thiscall" fn(*const u32, *const u32, bool) -> *const u32>,
+        entity_ptr: *const u32,
+        use_map_footprint: bool,
+    ) -> IVec3 {
+        let mut result = IVec3::default();
+        unsafe {
+            (original.original())(entity_ptr, &raw mut result as *const u32, use_map_footprint);
+        }
+        result
+    }
+
+    fn run_bfentity_get_footprint_tests(failure_log: &mut Option<std::fs::File>) -> bool {
+        let runner_config = ProptestConfig {
+            failure_persistence: Some(Box::new(super::NoopFailurePersistence)),
+            ..ProptestConfig::default()
+        };
+        let mut runner = proptest::test_runner::TestRunner::new(runner_config);
+        let test_name = "BFENTITY_GET_FOOTPRINT";
+        let mut fail_flag = false;
+
+        match runner.run(
+            &(-1000i32..1000i32, -1000i32..1000i32, -1000i32..1000i32, -8i32..8i32, proptest::bool::ANY),
+            |(fx, fy, fz, rotation, use_map_footprint)| {
+                let mut entity_type: BFEntityType = unsafe { std::mem::zeroed() };
+                entity_type.footprintx = fx;
+                entity_type.footprinty = fy;
+                entity_type.footprintz = fz;
+
+                let entity = BFEntity::new_for_test(&raw const entity_type as u32, rotation, 0);
+
+                let reimplemented_result = entity.get_footprint(use_map_footprint);
+                let real_result = call_original_get_footprint(BFENTITY_GET_FOOTPRINT, &raw const entity as *const u32, use_map_footprint);
+
+                assert_eq!(
+                    (real_result.x, real_result.y, real_result.z),
+                    (reimplemented_result.x, reimplemented_result.y, reimplemented_result.z),
+                    "BFEntity::get_footprint mismatch: fx={}, fy={}, fz={}, rotation={}, use_map_footprint={}, real={:?}, reimplemented={:?}",
+                    fx, fy, fz, rotation, use_map_footprint, real_result, reimplemented_result
+                );
+                Ok(())
+            },
+        ) {
+            Ok(_) => {
+                info!("Proptest passed for {}", test_name);
+                write_success_line(failure_log, test_name);
+            }
+            Err(e) => {
+                error!("Proptest failed: {:?}", e);
+                if let proptest::test_runner::TestError::Fail(r, (fx, fy, fz, rotation, use_map_footprint)) = e {
+                    let failure_line = format!(
+                        "{}: fx={}, fy={}, fz={}, rotation={}, use_map_footprint={}, reason={}\n",
+                        test_name, fx, fy, fz, rotation, use_map_footprint, r
+                    );
+                    if let Some(log_file) = failure_log {
+                        if let Err(write_err) = log_file.write_all(failure_line.as_bytes()) {
+                            error!("Failed to write to failure log: {}", write_err);
+                        }
+                    }
+                    fail_flag = true;
+                }
+            }
+        }
+
+        fail_flag
+    }
+
+    /// `ZTUnit::getFootprint`'s `use_map_footprint=true` branch virtual-dispatches through
+    /// `entity_type`'s vtable (not `this`'s own), so the fixture's `ZTUnitType` needs a real
+    /// vtable pointer - see `ZTUnitType::new_for_test` / `ztunit-ztanimal-footprint-crash-investigation.md`.
+    fn run_ztunit_get_footprint_tests(failure_log: &mut Option<std::fs::File>) -> bool {
+        let runner_config = ProptestConfig {
+            failure_persistence: Some(Box::new(super::NoopFailurePersistence)),
+            ..ProptestConfig::default()
+        };
+        let mut runner = proptest::test_runner::TestRunner::new(runner_config);
+        let test_name = "ZTUNIT_GET_FOOTPRINT";
+        let mut fail_flag = false;
+
+        match runner.run(
+            &(
+                -1000i32..1000i32,
+                -1000i32..1000i32,
+                -1000i32..1000i32,
+                -1000i32..1000i32,
+                -8i32..8i32,
+                proptest::bool::ANY,
+            ),
+            |(fx, fy, fz, map_footprint, rotation, use_map_footprint)| {
+                let entity_type = ZTUnitType::new_for_test(IVec3::new(fx, fy, fz), map_footprint);
+                let entity = ZTUnit::new_for_test(&raw const entity_type as u32, rotation, 0);
+
+                let reimplemented_result = entity.get_footprint(use_map_footprint);
+                let real_result = call_original_get_footprint(ZTUNIT_GET_FOOTPRINT, &raw const entity as *const u32, use_map_footprint);
+
+                assert_eq!(
+                    (real_result.x, real_result.y, real_result.z),
+                    (reimplemented_result.x, reimplemented_result.y, reimplemented_result.z),
+                    "ZTUnit::get_footprint mismatch: fx={}, fy={}, fz={}, map_footprint={}, rotation={}, use_map_footprint={}, real={:?}, reimplemented={:?}",
+                    fx, fy, fz, map_footprint, rotation, use_map_footprint, real_result, reimplemented_result
+                );
+                Ok(())
+            },
+        ) {
+            Ok(_) => {
+                info!("Proptest passed for {}", test_name);
+                write_success_line(failure_log, test_name);
+            }
+            Err(e) => {
+                error!("Proptest failed: {:?}", e);
+                if let proptest::test_runner::TestError::Fail(r, (fx, fy, fz, map_footprint, rotation, use_map_footprint)) = e {
+                    let failure_line = format!(
+                        "{}: fx={}, fy={}, fz={}, map_footprint={}, rotation={}, use_map_footprint={}, reason={}\n",
+                        test_name, fx, fy, fz, map_footprint, rotation, use_map_footprint, r
+                    );
+                    if let Some(log_file) = failure_log {
+                        if let Err(write_err) = log_file.write_all(failure_line.as_bytes()) {
+                            error!("Failed to write to failure log: {}", write_err);
+                        }
+                    }
+                    fail_flag = true;
+                }
+            }
+        }
+
+        fail_flag
+    }
+
+    /// `ZTAnimal::getFootprint`'s `is_egg`/`is_boxed` branches virtual-dispatch through
+    /// `entity_type`'s vtable unconditionally (regardless of `use_map_footprint`) - same fixture
+    /// requirement as `ZTUnit` above.
+    fn run_ztanimal_get_footprint_tests(failure_log: &mut Option<std::fs::File>) -> bool {
+        let runner_config = ProptestConfig {
+            failure_persistence: Some(Box::new(super::NoopFailurePersistence)),
+            ..ProptestConfig::default()
+        };
+        let mut runner = proptest::test_runner::TestRunner::new(runner_config);
+        let test_name = "ZTANIMAL_GET_FOOTPRINT";
+        let mut fail_flag = false;
+
+        match runner.run(
+            &(
+                (-1000i32..1000i32, -1000i32..1000i32, -1000i32..1000i32),
+                -1000i32..1000i32,
+                (-1000i32..1000i32, -1000i32..1000i32, -1000i32..1000i32),
+                (-1000i32..1000i32, -1000i32..1000i32, -1000i32..1000i32),
+                -8i32..8i32,
+                proptest::bool::ANY,
+                proptest::bool::ANY,
+                proptest::bool::ANY,
+            ),
+            |((fx, fy, fz), map_footprint, box_footprint, egg_footprint, rotation, use_map_footprint, is_egg, is_boxed)| {
+                let entity_type = ZTAnimalType::new_for_test(
+                    IVec3::new(fx, fy, fz),
+                    map_footprint,
+                    IVec3::new(box_footprint.0, box_footprint.1, box_footprint.2),
+                    IVec3::new(egg_footprint.0, egg_footprint.1, egg_footprint.2),
+                );
+                let entity = ZTAnimal::new_for_test(&raw const entity_type as u32, rotation, 0, is_egg, is_boxed);
+
+                let reimplemented_result = entity.get_footprint(use_map_footprint);
+                let real_result = call_original_get_footprint(ZTANIMAL_GET_FOOTPRINT, &raw const entity as *const u32, use_map_footprint);
+
+                assert_eq!(
+                    (real_result.x, real_result.y, real_result.z),
+                    (reimplemented_result.x, reimplemented_result.y, reimplemented_result.z),
+                    "ZTAnimal::get_footprint mismatch: is_egg={}, is_boxed={}, rotation={}, use_map_footprint={}, real={:?}, reimplemented={:?}",
+                    is_egg, is_boxed, rotation, use_map_footprint, real_result, reimplemented_result
+                );
+                Ok(())
+            },
+        ) {
+            Ok(_) => {
+                info!("Proptest passed for {}", test_name);
+                write_success_line(failure_log, test_name);
+            }
+            Err(e) => {
+                error!("Proptest failed: {:?}", e);
+                if let proptest::test_runner::TestError::Fail(r, ((fx, fy, fz), map_footprint, box_footprint, egg_footprint, rotation, use_map_footprint, is_egg, is_boxed)) = e {
+                    let failure_line = format!(
+                        "{}: fx={}, fy={}, fz={}, map_footprint={}, box_footprint={:?}, egg_footprint={:?}, rotation={}, use_map_footprint={}, is_egg={}, is_boxed={}, reason={}\n",
+                        test_name, fx, fy, fz, map_footprint, box_footprint, egg_footprint, rotation, use_map_footprint, is_egg, is_boxed, r
+                    );
+                    if let Some(log_file) = failure_log {
+                        if let Err(write_err) = log_file.write_all(failure_line.as_bytes()) {
+                            error!("Failed to write to failure log: {}", write_err);
+                        }
+                    }
+                    fail_flag = true;
+                }
+            }
+        }
+
+        fail_flag
     }
 }

--- a/openzt/src/resource_manager/mod_config.rs
+++ b/openzt/src/resource_manager/mod_config.rs
@@ -414,6 +414,7 @@ fn get_temp_config_path() -> PathBuf {
 mod tests {
     use super::*;
     use crate::logging::LogLevel;
+    use tracing_subscriber::filter::LevelFilter;
 
     #[test]
     fn test_default_config() {

--- a/openzt/src/zthabitatmgr.rs
+++ b/openzt/src/zthabitatmgr.rs
@@ -104,7 +104,7 @@ impl fmt::Display for ZTHabitatMgr {
 pub struct ZTHabitat {
     vtable: u32,                 // 0x000
     zt_show_info_ptr: u32,       // 0x004
-    pad1: [u8; 0x38],            // ----------------------- padding: 60 bytes
+    pad1: [u8; 0x38],            // ----------------------- padding: 56 bytes
     exhibit_tile_ptr: u32,       // 0x040 // Seems incorrect?
     pad2: [u8; 0x48],            // ----------------------- padding: 72 bytes
     entrance_tile_ptr: u32,      // 0x08c
@@ -124,10 +124,13 @@ pub struct ZTHabitat {
     created_timestamp: FileTime, // 0x120
     unknown_nt_time: FileTime,   // 0x128
     pad5: [u8; 0x24],            // ----------------------- padding: 36 bytes
-    exhibit_name: ZTBoundedString,
+    exhibit_name: ZTBoundedString, // 0x154
+    pad6: [u8; 0x28],            // ----------------------- padding: 40 bytes
+    tank_height: u32,            // 0x188
 }
 
 impl ZTHabitat {
+    const TANK_VTABLE_PTR: u32 = 0x006312bc;
     pub fn get_gate_tile_in(&self) -> Option<BFTile> {
         if self.entrance_tile_ptr == 0 {
             return None;
@@ -144,6 +147,14 @@ impl ZTHabitat {
             }
         let ztwm = globals().ztworldmgr();
         ztwm.get_neighbour(&tile, Direction::from(self.entrance_rotation))
+    }
+
+    pub fn is_tank(&self) -> bool {
+        self.vtable == Self::TANK_VTABLE_PTR
+    }
+
+    pub fn is_show_tank(&self) -> bool {
+        self.zt_show_info_ptr != 0
     }
 }
 
@@ -240,11 +251,11 @@ pub mod hooks_zthabitatmgr {
 
     // 00410349 BFTile * __thiscall OOAnalyzer::ZTHabitat::getGateTileIn(ZTHabitat *this)
     #[detour(GET_GATE_TILE_IN)]
-    unsafe extern "thiscall" fn get_gate_tile_in(_this: u32) -> u32 {
+    unsafe extern "thiscall" fn get_gate_tile_in(_this: *const u32) -> *const u32 {
         let habitat = unsafe { ref_from_memory::<ZTHabitat>(_this) };
         match habitat.get_gate_tile_in() {
-            Some(tile) => globals().ztworldmgr().get_ptr_from_bftile(&tile),
-            None => 0,
+            Some(tile) => globals().ztworldmgr().get_ptr_from_bftile(&tile) as *const u32,
+            None => std::ptr::null(),
         }
     }
 }

--- a/openzt/src/zthabitatmgr.rs
+++ b/openzt/src/zthabitatmgr.rs
@@ -132,6 +132,8 @@ pub struct ZTHabitat {
     is_filled: bool,             // 0x198 // Set true by ZTTankExhibit::fill(), false by ZTTankExhibit::drain().
 }
 
+const _: () = assert!(std::mem::size_of::<ZTHabitat>() == 0x198);
+
 impl ZTHabitat {
     const TANK_VTABLE_PTR: u32 = 0x006312bc;
     pub fn get_gate_tile_in(&self) -> Option<BFTile> {

--- a/openzt/src/zthabitatmgr.rs
+++ b/openzt/src/zthabitatmgr.rs
@@ -125,8 +125,11 @@ pub struct ZTHabitat {
     unknown_nt_time: FileTime,   // 0x128
     pad5: [u8; 0x24],            // ----------------------- padding: 36 bytes
     exhibit_name: ZTBoundedString, // 0x154
-    pad6: [u8; 0x28],            // ----------------------- padding: 40 bytes
-    tank_height: u32,            // 0x188
+    pad6: [u8; 0x24],            // ----------------------- padding: 36 bytes
+    tank_height: u32,            // 0x184 // Actual structural tank height (ZTTankExhibit::getTankHeight/setTankHeight); not the field checkTankPlacement compares against, see water_level.
+    water_level: u32,            // 0x188 // Current water level (ZTTankExhibit::getWaterLevel); this is what checkTankPlacement's height comparisons actually use.
+    pad7: [u8; 0xc],             // ----------------------- padding: 12 bytes
+    is_filled: bool,             // 0x198 // Set true by ZTTankExhibit::fill(), false by ZTTankExhibit::drain().
 }
 
 impl ZTHabitat {

--- a/openzt/src/ztmapview.rs
+++ b/openzt/src/ztmapview.rs
@@ -3,10 +3,10 @@ use num_enum::FromPrimitive;
 use openzt_detour_macro::detour_mod;
 use tracing::info;
 
-use crate::bfentitytype::{zt_entity_type_class_is, ZTEntityTypeClass};
+use crate::bfentitytype::{BFEntityType, ZTAnimalType, ZTEntityTypeClass, ZTSceneryType, ZTUnitType, zt_entity_type_class_is};
 use crate::globals::globals;
-use crate::util::{get_from_memory, ref_from_memory};
-use crate::ztworldmgr::{BFEntity, IVec3};
+use crate::util::{get_from_memory, ref_from_memory, Addr, MemAddr};
+use crate::ztworldmgr::{BFEntity, IVec3, ZTAnimal};
 // use crate::{
 //     util::get_from_memory,
 // };
@@ -40,15 +40,21 @@ use crate::ztworldmgr::{BFEntity, IVec3};
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct BFTile {
-    padding: [u8; 0x34],
+    padding: [u8; 0x10],
+    pub entity_ptr: u32, // 0x10 Pointer to the entity on this tile, if any
+    pub north_fence: u32, // 0x14 Change to &ZTFence when that type exists
+    pub east_fence: u32,  // 0x18
+    pub south_fence: u32, // 0x1c
+    pub west_fence: u32,  // 0x20
+    padding_2: [u8; 0x34 - 0x24],
     pub pos: IVec3, // 0x034 + 0xc
-    padding_2: [u8; 0x40],
+    padding_3: [u8; 0x40],
     unknown_byte_1: u8,     // 0x080
     pub unknown_byte_2: u8, // 0x081
     unknown_byte_3: u8,     // 0x082
     unknown_byte_4: u8,     // 0x083
     unknown_byte_5: u8,     // 0x084
-    padding_3: [u8; 0x8],   // Full size 0x8c
+    padding_4: [u8; 0x8],   // Full size 0x8c
 }
 
 impl PartialEq for BFTile {
@@ -66,15 +72,21 @@ impl fmt::Display for BFTile {
 impl BFTile {
     pub fn new(pos: IVec3, unknown_byte_2: u8) -> Self {
         BFTile {
-            padding: [0; 0x34],
+            padding: [0; 0x10],
+            entity_ptr: 0,
+            north_fence: 0,
+            east_fence: 0,
+            south_fence: 0,
+            west_fence: 0,
+            padding_2: [0; 0x10],
             pos,
-            padding_2: [0; 0x40],
+            padding_3: [0; 0x40],
             unknown_byte_1: 0,
             unknown_byte_2,
             unknown_byte_3: 0,
             unknown_byte_4: 0,
             unknown_byte_5: 0,
-            padding_3: [0; 0x8],
+            padding_4: [0; 0x8],
         }
     }
 
@@ -204,10 +216,10 @@ impl BFTile {
 
 #[detour_mod]
 pub mod zoo_ztmapview {
-    use tracing::info;
+    use tracing::{info, error};
 
     use crate::util::{get_from_memory, ref_from_memory};
-    use crate::ztmapview::{BFTile, ErrorStringId, ZTMapView};
+    use crate::ztmapview::{BFTile, ZTMapView};
     use crate::ztworldmgr::IVec3;
     use openzt_detour::generated::bftile::GET_LOCAL_ELEVATION;
     use openzt_detour::generated::ztmapview::CHECK_TANK_PLACEMENT;
@@ -220,7 +232,7 @@ pub mod zoo_ztmapview {
     //004df688
     #[detour(CHECK_TANK_PLACEMENT)]
     // fn check_tank_placement(ZTMapView *other_this, BFEntity *param_2, BFTile *param_3, int *param_4)
-    unsafe extern "stdcall" fn check_tank_placement(temp_entity_ptr: u32, tile: u32, response_ptr: *mut u32) -> bool {
+    unsafe extern "stdcall" fn check_tank_placement(temp_entity_ptr: *const u32, tile: *const u32, response_ptr: *mut u32) -> bool {
         let result = unsafe { CHECK_TANK_PLACEMENT_DETOUR.call(temp_entity_ptr, tile, response_ptr) };
 
         // let entity = get_from_memory(temp_entity);
@@ -229,15 +241,18 @@ pub mod zoo_ztmapview {
 
         // let zt_map_view = get_from_memory::<ZTMapView>(_this);
 
-        if let Err(reimplemented_result) = ZTMapView::check_tank_placement(temp_entity_ptr, bf_tile) {
-            if reimplemented_result == ErrorStringId::from(unsafe { *response_ptr }) {
-                info!("ZTMapView::checkTankPlacement success {:?}", reimplemented_result);
-            } else {
-                info!("Fail {:?}", ErrorStringId::from(unsafe { *response_ptr }));
+        let zt_result = if response_ptr.is_null() { 0 } else { get_from_memory::<u32>(response_ptr) };
+        match ZTMapView::check_tank_placement(temp_entity_ptr, bf_tile) {
+            Err(reimplemented_result) => {
+                if zt_result != reimplemented_result.clone() as u32 {
+                    error!("ZTMapView::checkTankPlacement mismatch between reimplementation and game result! Reimplementation: {:?}, Game: {:#x}", reimplemented_result, zt_result);
+                }
             }
-            // info!("ZTMapView::checkTankPlacement 1 -> {:?}", reimplemented_result);
-        } else {
-            info!("ZTMapView::checkTankPlacement 0 -> 0");
+            Ok(()) => {
+                if zt_result != 0 {
+                    error!("ZTMapView::checkTankPlacement mismatch: reimplementation returned Ok but game returned {:#x}", zt_result);
+                }
+            }
         }
 
         // info!("ZTMapView::checkTankPlacement {}, {:p} -> {:#x}", result, response_ptr, unsafe{*response_ptr});
@@ -253,7 +268,7 @@ pub mod zoo_ztmapview {
 
     // 0040f24d int __thiscall OOAnalyzer::BFTile::getLocalElevation(BFTile *this,BFPos *param_1)
     #[detour(GET_LOCAL_ELEVATION)]
-    unsafe extern "thiscall" fn get_local_elevation(_this: u32, pos: u32) -> i32 {
+    unsafe extern "thiscall" fn get_local_elevation(_this: *const u32, pos: *const u32) -> i32 {
         let tile = unsafe { ref_from_memory::<BFTile>(_this) };
         let pos_vec = get_from_memory::<IVec3>(pos);
         tile.get_local_elevation(pos_vec)
@@ -288,39 +303,95 @@ pub enum ErrorStringId {
 }
 
 impl ZTMapView {
-    pub fn check_tank_placement(temp_entity_ptr: u32, tile: &BFTile) -> Result<(), ErrorStringId> {
-        info!("Entity Ptr {:#x} -> {:#x}", temp_entity_ptr, get_from_memory::<u32>(temp_entity_ptr));
+    pub fn check_tank_placement(temp_entity_ptr: impl MemAddr, tile: &BFTile) -> Result<(), ErrorStringId> {
+        // info!("Entity Ptr {:#x} -> {:#x}", Addr::of(temp_entity_ptr), get_from_memory::<u32>(temp_entity_ptr));
         let temp_entity = unsafe { ref_from_memory::<BFEntity>(temp_entity_ptr) };
         let habitat_mgr = globals().zthabitatmgr();
         let Some(habitat) = habitat_mgr.get_habitat(tile.pos.x, tile.pos.y) else {
             info!("No habitat found at tile position: {:?}", tile.pos);
             return Ok(());
         };
+        // info!("Found habitat: {}", habitat.exhibit_name().to_string());
+        if !habitat.is_tank(){
+            return Ok(());
+        }
         let entity_type_class = temp_entity.entity_type_class();
-        info!("Checking tank placement for entity type class: {:?}", entity_type_class);
         if !zt_entity_type_class_is(&entity_type_class, &ZTEntityTypeClass::Keeper) {
-            info!("Not keeper, checking gate tile");
             if let Some(t) = habitat.get_gate_tile_in()
                 && temp_entity.is_on_tile(&t) {
                     return Err(ErrorStringId::ObjectTooCloseToLadderOrPlatform);
                 }
         }
-        // TODO: Fix this, currently we are trying to read a ZTSceneryType from the address of a ZTScenery entity instance
-        // if zt_entity_type_class_is(&entity_type_class, &ZTEntityTypeClass::Scenery) {
-        //     let scenery_entity = match checked_get_from_memory::<ZTSceneryType>(temp_entity_ptr) {
-        //         Ok(entity) => entity,
-        //         Err(e) => {
-        //             panic!("Failed to get ZTSceneryType from memory for entity at ptr: {:#x}, error: {}", temp_entity_ptr, e);
-        //         }
-        //     };
+        if zt_entity_type_class_is(&entity_type_class, &ZTEntityTypeClass::Scenery) {
+            let scenery_entity_type = unsafe { ref_from_memory::<ZTSceneryType>(*temp_entity.inner_class_ptr()) };
 
-        //     if !scenery_entity.underwater || !scenery_entity.surface {
-        //         return Err(ErrorStringId::ObjectCannotBePlacedInTank);
-        //     }
-        // }
-        // match  {
-        //     ZTEntityTypeClass::ZTKeeper
-        // }
+            if !scenery_entity_type.underwater && !scenery_entity_type.surface {
+                return Err(ErrorStringId::ObjectCannotBePlacedInTank);
+            }
+
+            if scenery_entity_type.surface && *habitat.tank_height() < scenery_entity_type.depth {
+                return Err(ErrorStringId::ObjectMustBePlacedInADeeperTank);
+            }
+        }
+
+        if zt_entity_type_class_is(&entity_type_class, &ZTEntityTypeClass::Animal) {
+            let animal_entity = unsafe { ref_from_memory::<ZTAnimal>(temp_entity_ptr) };
+            let animal_entity_type = unsafe { ref_from_memory::<ZTAnimalType>(*temp_entity.inner_class_ptr()) };
+            // TODO: underwater or only underwater? Assume 'only' as I suspect otherwise they'll get weird animations when spawning in water, under the surface but would need to test
+            // Or potentially underwater and !surface - No onlyUnderwater
+            if *animal_entity.is_egg() && !animal_entity_type.underwater {
+                return Err(ErrorStringId::EggsMustBePlacedOnLand);
+            }
+            if *habitat.tank_height() < animal_entity_type.ztunit_type.bfunit_type.depth {
+                // TODO: Add an extra message for animals rather than objects
+                return Err(ErrorStringId::ObjectMustBePlacedInADeeperTank);
+            }
+            // TankWithWater check; onlyUnderwater?
+            if animal_entity_type.underwater && *habitat.tank_height() < 1 {
+                return Err(ErrorStringId::AnimalMustBePlacedInATankWithWater);
+            }
+        }
+
+        if zt_entity_type_class_is(&entity_type_class, &ZTEntityTypeClass::ZTUnit) {
+            let ztunit_entity_type = unsafe { ref_from_memory::<ZTUnitType>(*temp_entity.inner_class_ptr()) };
+            if !ztunit_entity_type.underwater {
+                // info!("type: {}, subtype: {}, underwater: {}, surface: {}", ztunit_entity_type.bfunit_type.zt_type.to_string(), ztunit_entity_type.bfunit_type.zt_sub_type.to_string(), ztunit_entity_type.underwater, ztunit_entity_type.surface);
+                if zt_entity_type_class_is(&entity_type_class, &ZTEntityTypeClass::Staff) {
+                    return Err(ErrorStringId::StaffCannotBePlacedInTank);
+                } else {
+                    return Err(ErrorStringId::AnimalMustBePlacedOnLand);
+                }
+            }
+        }
+
+        let bfentity_entity_type = unsafe { ref_from_memory::<BFEntityType>(*temp_entity.inner_class_ptr()) };
+        if bfentity_entity_type.show && !habitat.is_show_tank() {
+            return Err(ErrorStringId::ShowObjectMustBePlacedInShowTank);
+        }
+
+        if habitat.is_show_tank() && !bfentity_entity_type.show {
+            return Err(ErrorStringId::ObjectCannotBePlacedInShowTank);
+        }
+
+        if temp_entity.check_avoid_edges(tile) {
+            return Err(ErrorStringId::ObjectCannotBePlacedAgainstTankWall);
+        }
+
+        // Need to thoroughly check/test this logic
+        let tile_entity_ptr = tile.entity_ptr;
+        if tile_entity_ptr != 0 {
+            let tile_entity = unsafe { ref_from_memory::<BFEntity>(tile_entity_ptr) };
+            let tile_entity_type_class = tile_entity.entity_type_class();
+            if zt_entity_type_class_is(&tile_entity_type_class, &ZTEntityTypeClass::Scenery) {
+                let tile_scenery_type = unsafe { ref_from_memory::<ZTSceneryType>(*tile_entity.inner_class_ptr()) };
+                if !tile_scenery_type.surface {
+                    // return Ok(());
+                    // TODO: ZT doesn't set the error message code for this case, but does return false?
+                    return Err(ErrorStringId::UnknownError)
+                }
+            }
+        }
+
 
         Ok(())
     }

--- a/openzt/src/ztmapview.rs
+++ b/openzt/src/ztmapview.rs
@@ -218,7 +218,7 @@ impl BFTile {
 pub mod zoo_ztmapview {
     use tracing::{info, error};
 
-    use crate::util::{get_from_memory, ref_from_memory};
+    use crate::util::{get_from_memory, ref_from_memory, save_to_memory};
     use crate::ztmapview::{BFTile, ZTMapView};
     use crate::ztworldmgr::IVec3;
     use openzt_detour::generated::bftile::GET_LOCAL_ELEVATION;
@@ -233,7 +233,7 @@ pub mod zoo_ztmapview {
     #[detour(CHECK_TANK_PLACEMENT)]
     // fn check_tank_placement(ZTMapView *other_this, BFEntity *param_2, BFTile *param_3, int *param_4)
     unsafe extern "stdcall" fn check_tank_placement(temp_entity_ptr: *const u32, tile: *const u32, response_ptr: *mut u32) -> bool {
-        let result = unsafe { CHECK_TANK_PLACEMENT_DETOUR.call(temp_entity_ptr, tile, response_ptr) };
+        let _result = unsafe { CHECK_TANK_PLACEMENT_DETOUR.call(temp_entity_ptr, tile, response_ptr) };
 
         // let entity = get_from_memory(temp_entity);
 
@@ -247,17 +247,19 @@ pub mod zoo_ztmapview {
                 if zt_result != reimplemented_result.clone() as u32 {
                     error!("ZTMapView::checkTankPlacement mismatch between reimplementation and game result! Reimplementation: {:?}, Game: {:#x}", reimplemented_result, zt_result);
                 }
+
+                if !response_ptr.is_null() {
+                    save_to_memory(response_ptr, reimplemented_result as u32);
+                }
+                false
             }
             Ok(()) => {
                 if zt_result != 0 {
                     error!("ZTMapView::checkTankPlacement mismatch: reimplementation returned Ok but game returned {:#x}", zt_result);
                 }
+                true
             }
         }
-
-        // info!("ZTMapView::checkTankPlacement {}, {:p} -> {:#x}", result, response_ptr, unsafe{*response_ptr});
-        result
-        // true
     }
 
     // #[hook(unsafe extern "thiscall" BFUIMgr_display_message, offset = 0x0009ccc3)]
@@ -329,7 +331,7 @@ impl ZTMapView {
                 return Err(ErrorStringId::ObjectCannotBePlacedInTank);
             }
 
-            if scenery_entity_type.surface && *habitat.tank_height() < scenery_entity_type.depth {
+            if scenery_entity_type.surface && *habitat.water_level() < scenery_entity_type.depth {
                 return Err(ErrorStringId::ObjectMustBePlacedInADeeperTank);
             }
         }
@@ -342,12 +344,15 @@ impl ZTMapView {
             if *animal_entity.is_egg() && !animal_entity_type.underwater {
                 return Err(ErrorStringId::EggsMustBePlacedOnLand);
             }
-            if *habitat.tank_height() < animal_entity_type.ztunit_type.bfunit_type.depth {
+            if *habitat.water_level() < animal_entity_type.ztunit_type.bfunit_type.depth {
                 // TODO: Add an extra message for animals rather than objects
                 return Err(ErrorStringId::ObjectMustBePlacedInADeeperTank);
             }
             // TankWithWater check; onlyUnderwater?
-            if animal_entity_type.underwater && *habitat.tank_height() < 1 {
+            if animal_entity_type.underwater
+                && !animal_entity.is_boxed()
+                && (!habitat.is_filled() || *habitat.water_level() < 1)
+            {
                 return Err(ErrorStringId::AnimalMustBePlacedInATankWithWater);
             }
         }
@@ -384,7 +389,7 @@ impl ZTMapView {
             let tile_entity_type_class = tile_entity.entity_type_class();
             if zt_entity_type_class_is(&tile_entity_type_class, &ZTEntityTypeClass::Scenery) {
                 let tile_scenery_type = unsafe { ref_from_memory::<ZTSceneryType>(*tile_entity.inner_class_ptr()) };
-                if !tile_scenery_type.surface {
+                if tile_scenery_type.surface {
                     // return Ok(());
                     // TODO: ZT doesn't set the error message code for this case, but does return false?
                     return Err(ErrorStringId::UnknownError)

--- a/openzt/src/ztworldmgr.rs
+++ b/openzt/src/ztworldmgr.rs
@@ -3,6 +3,7 @@ use itertools::Itertools;
 use num_enum::FromPrimitive;
 use openzt_detour_macro::detour_mod;
 use std::cmp::max;
+use std::mem;
 use std::str::FromStr;
 use std::{collections::HashMap, fmt};
 use tracing::{error, info};
@@ -161,6 +162,8 @@ pub struct BFEntity { // Full size is 0x154 bytes
     map_footprint: i32,        // 0x150
 }
 
+const _: () = assert!(mem::size_of::<BFEntity>() == 0x154);
+
 impl fmt::Display for BFEntity {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
@@ -172,6 +175,16 @@ impl fmt::Display for BFEntity {
 }
 
 impl BFEntity {
+    /// Builds a zero-filled `BFEntity` for tests, with only the fields relevant to
+    /// pure (globals()-free) logic populated. Mirrors `BFTile::new` in `ztmapview.rs`.
+    pub fn new_for_test(inner_class_ptr: u32, rotation: i32, map_footprint: i32) -> Self {
+        let mut entity: BFEntity = unsafe { mem::zeroed() };
+        entity.inner_class_ptr = inner_class_ptr;
+        entity.rotation = rotation;
+        entity.map_footprint = map_footprint;
+        entity
+    }
+
     pub fn entity_type_class(&self) -> ZTEntityTypeClass {
         ZTEntityTypeClass::from(get_from_memory::<u32>(self.inner_class_ptr))
     }
@@ -299,6 +312,17 @@ pub(crate) struct BFUnit {
     padding: [u8; 0x214-0x154], // ----- padding: 192 bytes
 }
 
+const _: () = assert!(mem::size_of::<BFUnit>() == 0x214);
+
+impl BFUnit {
+    /// Test-only fixture, see `BFEntity::new_for_test`.
+    pub fn new_for_test(inner_class_ptr: u32, rotation: i32, map_footprint: i32) -> Self {
+        BFUnit {
+            base: BFEntity::new_for_test(inner_class_ptr, rotation, map_footprint),
+            padding: [0; 0x214 - 0x154],
+        }
+    }
+}
 
 impl std::ops::Deref for BFUnit {
     type Target = BFEntity;
@@ -321,7 +345,16 @@ pub(crate) struct ZTUnit {
     padding: [u8; 0x260-0x214], // ----- padding: 76 bytes
 }
 
+const _: () = assert!(mem::size_of::<ZTUnit>() == 0x260);
+
 impl ZTUnit {
+    /// Test-only fixture, see `BFEntity::new_for_test`.
+    pub fn new_for_test(inner_class_ptr: u32, rotation: i32, map_footprint: i32) -> Self {
+        ZTUnit {
+            base: BFUnit::new_for_test(inner_class_ptr, rotation, map_footprint),
+            padding: [0; 0x260 - 0x214],
+        }
+    }
 
     pub fn entity_type(&self) -> &'static ZTUnitType {
         unsafe { ref_from_memory(self.inner_class_ptr) }
@@ -331,9 +364,10 @@ impl ZTUnit {
         if !use_map_footprint {
             self.base.get_footprint(use_map_footprint)
         } else {
+            let map_footprint = self.entity_type().map_footprint;
             IVec3 {
-                x: self.map_footprint as i32,
-                y: self.map_footprint as i32,
+                x: map_footprint,
+                y: map_footprint,
                 z: 0,
             }
         }
@@ -356,7 +390,7 @@ impl std::ops::DerefMut for ZTUnit {
 #[derive(Debug, Getters)]
 #[get = "pub"]
 #[repr(C)]
-pub(crate) struct ZTAnimal {
+pub(crate) struct ZTAnimal { // bytes: 0x3a8 = 936 bytes
     base: ZTUnit,  // offset: 0x0000
     _pad_0x0260: [u8; 300],
     food_tile: *const BFTile,  // offset: 0x038c
@@ -376,7 +410,18 @@ pub(crate) struct ZTAnimal {
     mbr_0x3b4: u8,  // offset: 0x03b4
 }
 
+const _: () = assert!(mem::size_of::<ZTAnimal>() == 0x3a8);
+
 impl ZTAnimal {
+    /// Test-only fixture, see `BFEntity::new_for_test`. `mem::zeroed()` is safe here since
+    /// every field is an integer/bool/byte-array/raw-pointer, none of them references or niche types.
+    pub fn new_for_test(inner_class_ptr: u32, rotation: i32, map_footprint: i32, is_egg: bool, is_boxed: bool) -> Self {
+        let mut animal: ZTAnimal = unsafe { mem::zeroed() };
+        animal.base = ZTUnit::new_for_test(inner_class_ptr, rotation, map_footprint);
+        animal.is_egg = is_egg;
+        animal.is_boxed = is_boxed;
+        animal
+    }
 
     pub fn entity_type(&self) -> &'static ZTAnimalType {
         unsafe { ref_from_memory(self.inner_class_ptr) }
@@ -395,9 +440,9 @@ impl ZTAnimal {
         };
 
         if self.rotation % 4 == 0 {
-            IVec3 { x: footprint.y, y: footprint.x, z: footprint.z }
-        } else {
             IVec3 { x: footprint.x, y: footprint.y, z: footprint.z }
+        } else {
+            IVec3 { x: footprint.y, y: footprint.x, z: footprint.z }
         }
     }
 }
@@ -1298,3 +1343,201 @@ pub fn get_entity_type_by_id(id: u32) -> u32 {
 // struct BFMap {
 //     padding: [u8; 0x5c],
 // }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bfentitytype::BFEntityType;
+
+    // Explicit list (not derived from the enum) so it visibly needs updating when a
+    // variant is added and the match arm in `FromStr` is forgotten.
+    const ZT_ENTITY_CLASS_CASES: &[(ZTEntityClass, &str)] = &[
+        (ZTEntityClass::Food, "food"),
+        (ZTEntityClass::Path, "path"),
+        (ZTEntityClass::Fences, "fences"),
+        (ZTEntityClass::Building, "building"),
+        (ZTEntityClass::Animal, "animal"),
+        (ZTEntityClass::Guest, "guest"),
+        (ZTEntityClass::Scenery, "scenery"),
+        (ZTEntityClass::Keeper, "keeper"),
+        (ZTEntityClass::MaintenanceWorker, "maintenanceworker"),
+        (ZTEntityClass::TourGuide, "tourguide"),
+        (ZTEntityClass::Drt, "drt"),
+        (ZTEntityClass::Ambient, "ambient"),
+        (ZTEntityClass::Rubble, "rubble"),
+        (ZTEntityClass::TankWall, "tankwall"),
+        (ZTEntityClass::TankFilter, "tankfilter"),
+    ];
+
+    #[test]
+    fn test_zt_entity_class_from_str_round_trip() {
+        for (variant, s) in ZT_ENTITY_CLASS_CASES {
+            assert_eq!(s.parse::<ZTEntityClass>().unwrap(), *variant, "failed to parse '{}'", s);
+        }
+    }
+
+    #[test]
+    fn test_zt_entity_class_from_str_case_insensitive() {
+        assert_eq!("Animal".parse::<ZTEntityClass>().unwrap(), ZTEntityClass::Animal);
+        assert_eq!("ANIMAL".parse::<ZTEntityClass>().unwrap(), ZTEntityClass::Animal);
+        assert_eq!("aNiMaL".parse::<ZTEntityClass>().unwrap(), ZTEntityClass::Animal);
+    }
+
+    #[test]
+    fn test_zt_entity_class_from_str_unknown_is_err() {
+        assert!("not_a_real_entity_class".parse::<ZTEntityClass>().is_err());
+    }
+
+    fn entity_type_with_avoid_edges(avoid_edges: u32) -> BFEntityType {
+        let mut entity_type: BFEntityType = unsafe { mem::zeroed() };
+        entity_type.avoid_edges = avoid_edges;
+        entity_type
+    }
+
+    #[test]
+    fn test_check_avoid_edges_zero_always_false() {
+        let entity_type = entity_type_with_avoid_edges(0);
+        let entity = BFEntity::new_for_test(&entity_type as *const BFEntityType as u32, 0, 0);
+
+        let mut tile = BFTile::new(IVec3::new(0, 0, 0), 0);
+        tile.north_fence = 1;
+        tile.east_fence = 1;
+        tile.south_fence = 1;
+        tile.west_fence = 1;
+
+        assert!(!entity.check_avoid_edges(&tile), "avoid_edges == 0 should always return false, regardless of fence state");
+    }
+
+    #[test]
+    fn test_check_avoid_edges_radius_zero_no_fences() {
+        let entity_type = entity_type_with_avoid_edges(1);
+        let entity = BFEntity::new_for_test(&entity_type as *const BFEntityType as u32, 0, 0);
+
+        let tile = BFTile::new(IVec3::new(0, 0, 0), 0);
+
+        assert!(!entity.check_avoid_edges(&tile));
+    }
+
+    #[test]
+    fn test_check_avoid_edges_radius_zero_each_fence_direction_triggers() {
+        let entity_type = entity_type_with_avoid_edges(1);
+        let entity = BFEntity::new_for_test(&entity_type as *const BFEntityType as u32, 0, 0);
+        let pos = IVec3::new(0, 0, 0);
+
+        let mut north = BFTile::new(pos, 0);
+        north.north_fence = 1;
+        assert!(entity.check_avoid_edges(&north), "north_fence alone should trigger avoid_edges");
+
+        let mut east = BFTile::new(pos, 0);
+        east.east_fence = 1;
+        assert!(entity.check_avoid_edges(&east), "east_fence alone should trigger avoid_edges");
+
+        let mut south = BFTile::new(pos, 0);
+        south.south_fence = 1;
+        assert!(entity.check_avoid_edges(&south), "south_fence alone should trigger avoid_edges");
+
+        let mut west = BFTile::new(pos, 0);
+        west.west_fence = 1;
+        assert!(entity.check_avoid_edges(&west), "west_fence alone should trigger avoid_edges");
+    }
+
+    // ZTUnit/ZTAnimal::get_footprint internal-consistency tests.
+    //
+    // These pin down our own reimplementation's branch behavior. Most of them can't be compared
+    // against `.original()` directly (unlike BFEntity's equivalent, see reimplementation_tests/mod.rs)
+    // because ZTAnimal's is_egg/is_boxed branches unconditionally virtual-dispatch through
+    // entity_type's vtable; see ztunit-ztanimal-footprint-crash-investigation.md for the confirmed
+    // root cause and the entity_type fixtures' real vtable pointer.
+
+    fn entity_type_with_footprint(x: i32, y: i32, z: i32) -> BFEntityType {
+        let mut entity_type: BFEntityType = unsafe { mem::zeroed() };
+        entity_type.footprintx = x;
+        entity_type.footprinty = y;
+        entity_type.footprintz = z;
+        entity_type
+    }
+
+    #[test]
+    fn test_ztunit_get_footprint_map_footprint_ignores_rotation() {
+        let entity_type = ZTUnitType::new_for_test(IVec3::default(), 42);
+        for rotation in [-8, -3, -1, 0, 1, 3, 4, 8] {
+            let entity = ZTUnit::new_for_test(&entity_type as *const ZTUnitType as u32, rotation, 0);
+            let footprint = entity.get_footprint(true);
+            assert_eq!(
+                (footprint.x, footprint.y, footprint.z),
+                (42, 42, 0),
+                "use_map_footprint=true should return {{map_footprint, map_footprint, 0}} regardless of rotation ({})",
+                rotation
+            );
+        }
+    }
+
+    #[test]
+    fn test_ztunit_get_footprint_delegates_to_base_when_not_using_map_footprint() {
+        let entity_type = entity_type_with_footprint(5, 7, 9);
+
+        let unrotated = ZTUnit::new_for_test(&entity_type as *const BFEntityType as u32, 0, 42);
+        let footprint = unrotated.get_footprint(false);
+        assert_eq!((footprint.x, footprint.y, footprint.z), (5, 7, 9));
+
+        let rotated = ZTUnit::new_for_test(&entity_type as *const BFEntityType as u32, 1, 42);
+        let footprint = rotated.get_footprint(false);
+        assert_eq!((footprint.x, footprint.y, footprint.z), (7, 5, 9), "odd rotation should swap x/y, matching BFEntity::get_footprint");
+    }
+
+    fn animal_type_with_footprints(egg: IVec3, boxed: IVec3) -> ZTAnimalType {
+        let mut entity_type: ZTAnimalType = unsafe { mem::zeroed() };
+        entity_type.egg_footprint = egg;
+        entity_type.box_footprint = boxed;
+        entity_type
+    }
+
+    #[test]
+    fn test_ztanimal_get_footprint_delegates_to_base_when_not_egg_or_boxed() {
+        let entity_type = entity_type_with_footprint(5, 7, 9);
+        let entity = ZTAnimal::new_for_test(&entity_type as *const BFEntityType as u32, 1, 0, false, false);
+
+        let footprint = entity.get_footprint(false);
+        assert_eq!(
+            (footprint.x, footprint.y, footprint.z),
+            (7, 5, 9),
+            "is_egg=false, is_boxed=false should delegate through ZTUnit/BFEntity::get_footprint"
+        );
+    }
+
+    #[test]
+    fn test_ztanimal_get_footprint_egg_uses_egg_footprint_with_rotation_swap() {
+        let entity_type = animal_type_with_footprints(IVec3::new(11, 22, 33), IVec3::new(99, 98, 97));
+
+        // Same swap direction as BFEntity::get_footprint's: rotation % 4 == 0 leaves x/y unswapped,
+        // any other rotation swaps them. Confirmed live against the real ZTAnimal::getFootprint -
+        // see ztunit-ztanimal-footprint-crash-investigation.md.
+        let unrotated = ZTAnimal::new_for_test(&entity_type as *const ZTAnimalType as u32, 0, 0, true, false);
+        let footprint = unrotated.get_footprint(false);
+        assert_eq!((footprint.x, footprint.y, footprint.z), (11, 22, 33));
+
+        let rotated = ZTAnimal::new_for_test(&entity_type as *const ZTAnimalType as u32, 1, 0, true, false);
+        let footprint = rotated.get_footprint(false);
+        assert_eq!((footprint.x, footprint.y, footprint.z), (22, 11, 33));
+    }
+
+    #[test]
+    fn test_ztanimal_get_footprint_boxed_uses_box_footprint() {
+        let entity_type = animal_type_with_footprints(IVec3::new(11, 22, 33), IVec3::new(99, 98, 97));
+
+        let entity = ZTAnimal::new_for_test(&entity_type as *const ZTAnimalType as u32, 0, 0, false, true);
+        let footprint = entity.get_footprint(false);
+        assert_eq!((footprint.x, footprint.y, footprint.z), (99, 98, 97));
+    }
+
+    #[test]
+    fn test_ztanimal_get_footprint_egg_and_boxed_prefers_egg() {
+        // Deliberate tie-break: the code checks `is_egg` before `is_boxed`, so when both are set
+        // egg_footprint wins. Distinct egg/box values here make a regression to box_footprint visible.
+        let entity_type = animal_type_with_footprints(IVec3::new(11, 22, 33), IVec3::new(99, 98, 97));
+
+        let entity = ZTAnimal::new_for_test(&entity_type as *const ZTAnimalType as u32, 0, 0, true, true);
+        let footprint = entity.get_footprint(false);
+        assert_eq!((footprint.x, footprint.y, footprint.z), (11, 22, 33), "is_egg=true, is_boxed=true should prefer egg_footprint");
+    }
+}

--- a/openzt/src/ztworldmgr.rs
+++ b/openzt/src/ztworldmgr.rs
@@ -7,8 +7,9 @@ use std::str::FromStr;
 use std::{collections::HashMap, fmt};
 use tracing::{error, info};
 
-use crate::bfentitytype::ZTEntityTypeClass;
-use crate::util::ZTBufferString;
+use crate::bfentitytype::{ZTAnimalType, ZTEntityTypeClass, ZTUnitType};
+use crate::shortcuts::M;
+use crate::util::{ZTBufferString, mut_from_memory};
 use crate::ztmapview::BFTile;
 use crate::{
     bfentitytype::{read_zt_entity_type_from_memory, BFEntityType, ZTEntityType, ZTSceneryType},
@@ -41,6 +42,31 @@ pub enum ZTEntityClass {
     Unknown = 0x0,
 }
 
+impl std::str::FromStr for ZTEntityClass {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "food" => Ok(ZTEntityClass::Food),
+            "path" => Ok(ZTEntityClass::Path),
+            "fences" => Ok(ZTEntityClass::Fences),
+            "building" => Ok(ZTEntityClass::Building),
+            "animal" => Ok(ZTEntityClass::Animal),
+            "guest" => Ok(ZTEntityClass::Guest),
+            "scenery" => Ok(ZTEntityClass::Scenery),
+            "keeper" => Ok(ZTEntityClass::Keeper),
+            "maintenanceworker" => Ok(ZTEntityClass::MaintenanceWorker),
+            "tourguide" => Ok(ZTEntityClass::TourGuide),
+            "drt" => Ok(ZTEntityClass::Drt),
+            "ambient" => Ok(ZTEntityClass::Ambient),
+            "rubble" => Ok(ZTEntityClass::Rubble),
+            "tankwall" => Ok(ZTEntityClass::TankWall),
+            "tankfilter" => Ok(ZTEntityClass::TankFilter),
+            _ => Err(format!("Unknown entity type: {}", s)),
+        }
+    }
+}
+
 // TODO: Make this look like other structs with proper offsets and padding ->
 #[derive(Debug, Getters)]
 #[get = "pub"]
@@ -53,6 +79,18 @@ pub struct ZTEntity {
     name: String,
     pos1: u32,
     pos2: u32,
+}
+
+#[derive(Debug)]
+struct ZTEntityWithPtr {
+    ptr: u32,
+    entity: ZTEntity,
+}
+
+#[derive(Debug)]
+struct ZTEntityTypeWithPtr {
+    ptr: u32,
+    entity_type: ZTEntityType,
 }
 
 // Move to util or use existing implementation
@@ -98,18 +136,16 @@ impl Rectangle {
 #[derive(Debug, Getters)]
 #[get = "pub"]
 #[repr(C)]
-pub struct BFEntity {
+pub struct BFEntity { // Full size is 0x154 bytes
     vtable: u32,
     padding: [u8; 0x104],
     name: ZTBufferString,      // 0x108
-    x_coord: i32,              // 0x114
-    y_coord: i32,              // 0x118
-    z_coord: i32,              // 0x11c
+    pos: IVec3,              // 0x114
     height_above_terrain: u32, // 0x120
     padding4: [u8; 0x4],       // ----- padding: 4 bytes
     inner_class_ptr: u32,      // 0x128
     rotation: i32,             // 0x12c
-    padding5: [u8; 0x14],      // ----- padding: 28 bytes
+    padding_2: [u8; 0xc],      // ----- padding: 28 bytes
     unknown_flag1: u8,         // 0x13c // isRemoved
     unknown_flag2: u8,         // 0x13d // isRemovedUndo
     unknown_flag3: u8,         // 0x13e
@@ -121,6 +157,8 @@ pub struct BFEntity {
     draw_dithered: u8,         // 0x144
     unknown_flag6: u8,         // 0x145 // If != 0; Draw selection graphic
     stop_at_end: u8,           // 0x146
+    padding_3: [u8; 0x9],      // ----- padding: 10 bytes
+    map_footprint: i32,        // 0x150
 }
 
 impl fmt::Display for BFEntity {
@@ -128,19 +166,18 @@ impl fmt::Display for BFEntity {
         write!(
             f,
             "BFEntity {{ name: {}, x_coord: {}, y_coord: {}, z_coord: {}, height_above_terrain: {}, rotation: {}, inner_class_ptr: {:#x}, visible: {}, snap_to_ground: {}, selected: {}, draw_dithered: {} }}",
-            self.name, self.x_coord, self.y_coord, self.z_coord, self.height_above_terrain, self.rotation, self.inner_class_ptr, self.visible, self.snap_to_ground, self.selected, self.draw_dithered
+            self.name, self.pos.x, self.pos.y, self.pos.z, self.height_above_terrain, self.rotation, self.inner_class_ptr, self.visible, self.snap_to_ground, self.selected, self.draw_dithered
         )
     }
 }
 
 impl BFEntity {
     pub fn entity_type_class(&self) -> ZTEntityTypeClass {
-        // info!("Getting inner_class_ptr: {:#x} -> {:#x}", self.inner_class_ptr, get_from_memory::<u32>(self.inner_class_ptr));
         ZTEntityTypeClass::from(get_from_memory::<u32>(self.inner_class_ptr))
     }
 
-    pub fn entity_type(&self) -> BFEntityType {
-        get_from_memory(self.inner_class_ptr)
+    pub fn entity_type(&self) -> &'static BFEntityType {
+        unsafe { ref_from_memory(self.inner_class_ptr) }
     }
 
     // TODO: Hook this and check that it works
@@ -179,10 +216,10 @@ impl BFEntity {
 
         // Construct and return the rectangle
         Rectangle {
-            min_x: self.x_coord - half_width,
-            min_y: self.y_coord - half_height,
-            max_x: self.x_coord + half_width,
-            max_y: self.y_coord + half_height,
+            min_x: self.pos.x - half_width,
+            min_y: self.pos.y - half_height,
+            max_x: self.pos.x + half_width,
+            max_y: self.pos.y + half_height,
         }
     }
 
@@ -195,7 +232,7 @@ impl BFEntity {
         get_from_memory::<IVec3>(footprint_ptr)
     }
 
-    pub fn get_footprint(&self) -> IVec3 {
+    pub fn get_footprint(&self, _use_map_footprint: bool) -> IVec3 {
         let entity_type = self.entity_type();
         if self.rotation % 4 == 0 {
             IVec3 {
@@ -213,9 +250,171 @@ impl BFEntity {
     }
 
     pub fn get_tile(&self) -> Option<BFTile> {
-        globals().ztworldmgr().get_tile_from_coords(self.x_coord, self.y_coord)
+        globals().ztworldmgr().get_tile_from_coords(self.pos.x, self.pos.y)
+    }
+
+    pub fn check_avoid_edges(&self, tile: &BFTile) -> bool {
+        let radius = self.entity_type().avoid_edges as i32 - 1;
+
+        if radius < 0 {
+            return false;
+        }
+
+        if radius == 0 {
+            return tile.north_fence != 0 || tile.east_fence != 0 || tile.south_fence != 0 || tile.west_fence != 0
+        }
+
+        // Check all tiles in a square of `radius` around the placement tile
+        let world_mgr = globals().ztworldmgr();
+
+        let x_min = tile.pos.x - radius;
+        let x_max = tile.pos.x + radius;
+        let y_min = tile.pos.y - radius;
+        let y_max = tile.pos.y + radius;
+
+        for check_x in x_min..=x_max {
+            for check_y in y_min..=y_max {
+                // Bounds check — skip tiles outside the map
+                if check_x < 0 || check_y < 0 || check_x >= world_mgr.map_x_size as i32 || check_y >= world_mgr.map_y_size as i32 {
+                    continue;
+                }
+
+                if let Some(tile) = world_mgr.get_tile_from_coords(check_x, check_y) {
+                    if tile.north_fence != 0 || tile.east_fence != 0 || tile.south_fence != 0 || tile.west_fence != 0 {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
     }
 }
+
+#[derive(Debug, Getters)]
+#[get = "pub"]
+#[repr(C)]
+pub(crate) struct BFUnit {
+    base: BFEntity, // bytes: 0x154 = 340 bytes
+    // TODO
+    padding: [u8; 0x214-0x154], // ----- padding: 192 bytes
+}
+
+
+impl std::ops::Deref for BFUnit {
+    type Target = BFEntity;
+    fn deref(&self) -> &BFEntity {
+        &self.base
+    }
+}
+
+impl std::ops::DerefMut for BFUnit {
+    fn deref_mut(&mut self) -> &mut BFEntity {
+        &mut self.base
+    }
+}
+
+#[derive(Debug, Getters)]
+#[get = "pub"]
+#[repr(C)]
+pub(crate) struct ZTUnit {
+    base: BFUnit, // bytes: 0x214 = 532 bytes
+    padding: [u8; 0x260-0x214], // ----- padding: 76 bytes
+}
+
+impl ZTUnit {
+
+    pub fn entity_type(&self) -> &'static ZTUnitType {
+        unsafe { ref_from_memory(self.inner_class_ptr) }
+    }
+
+    pub fn get_footprint(&self, use_map_footprint: bool) -> IVec3 {
+        if !use_map_footprint {
+            self.base.get_footprint(use_map_footprint)
+        } else {
+            IVec3 {
+                x: self.map_footprint as i32,
+                y: self.map_footprint as i32,
+                z: 0,
+            }
+        }
+    }
+}
+
+impl std::ops::Deref for ZTUnit {
+    type Target = BFUnit;
+    fn deref(&self) -> &BFUnit {
+        &self.base
+    }
+}
+
+impl std::ops::DerefMut for ZTUnit {
+    fn deref_mut(&mut self) -> &mut BFUnit {
+        &mut self.base
+    }
+}
+
+#[derive(Debug, Getters)]
+#[get = "pub"]
+#[repr(C)]
+pub(crate) struct ZTAnimal {
+    base: ZTUnit,  // offset: 0x0000
+    _pad_0x0260: [u8; 300],
+    food_tile: *const BFTile,  // offset: 0x038c
+    _pad_0x0390: [u8; 4],
+    is_boxed: bool,  // offset: 0x0394
+    is_egg: bool,  // offset: 0x0395
+    _pad_0x0396: [u8; 6],
+    mbr_0x39c: u8,  // offset: 0x039c
+    mbr_0x3a0: u8,  // offset: 0x03a0
+    mbr_0x3a4: i8,  // offset: 0x03a4
+    mbr_0x3a5: i8,  // offset: 0x03a5
+    is_dying: bool,  // offset: 0x03a6
+    mbr_0x3a7: i8,  // offset: 0x03a7
+    mbr_0x3a8: u8,  // offset: 0x03a8
+    mbr_0x3ac: u8,  // offset: 0x03ac
+    mbr_0x3b0: u8,  // offset: 0x03b0
+    mbr_0x3b4: u8,  // offset: 0x03b4
+}
+
+impl ZTAnimal {
+
+    pub fn entity_type(&self) -> &'static ZTAnimalType {
+        unsafe { ref_from_memory(self.inner_class_ptr) }
+    }
+
+    pub fn get_footprint(&self, use_map_footprint: bool) -> IVec3 {
+        if !self.is_egg && !self.is_boxed {
+            return self.base.get_footprint(use_map_footprint);
+        }
+
+        let type_info = self.entity_type();
+        let footprint = if self.is_egg {
+            type_info.egg_footprint
+        } else {
+            type_info.box_footprint
+        };
+
+        if self.rotation % 4 == 0 {
+            IVec3 { x: footprint.y, y: footprint.x, z: footprint.z }
+        } else {
+            IVec3 { x: footprint.x, y: footprint.y, z: footprint.z }
+        }
+    }
+}
+
+impl std::ops::Deref for ZTAnimal {
+    type Target = ZTUnit;
+    fn deref(&self) -> &ZTUnit {
+        &self.base
+    }
+}
+
+impl std::ops::DerefMut for ZTAnimal {
+    fn deref_mut(&mut self) -> &mut ZTUnit {
+        &mut self.base
+    }
+}
+
 
 // ZTAnimal -> 0x3a6 = animalDying
 
@@ -244,9 +443,11 @@ impl fmt::Display for ZTEntity {
 #[derive(Debug)]
 #[repr(C)]
 pub struct ZTWorldMgr {
-    padding_1: [u8; 0x34],
-    map_x_size: u32,
-    map_y_size: u32,
+    paddin_0: [u8; 0x14], // 0x10?
+    zoom_level: i32,
+    padding_1: [u8; 0x1c], // Tentative
+    pub map_x_size: u32,
+    pub map_y_size: u32,
     padding_2: [u8; 0x4],
     tile_array: u32,
     padding_3: [u8; 0x3c],
@@ -263,7 +464,8 @@ impl fmt::Display for ZTWorldMgr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "ZTWorldMgr {{ map_x_size: {}, map_y_size: {}, tile_array: {:#x}, entity_array_start: {:#x}, entity_array_end: {:#x}, entity_type_array_start: {:#x}, entity_type_array_end: {:#x} }}",
+            "ZTWorldMgr {{ zoom_level: {}, map_x_size: {}, map_y_size: {}, tile_array: {:#x}, entity_array_start: {:#x}, entity_array_end: {:#x}, entity_type_array_start: {:#x}, entity_type_array_end: {:#x} }}",
+            self.zoom_level,
             self.map_x_size,
             self.map_y_size,
             self.tile_array,
@@ -294,6 +496,14 @@ const TILE_SIZE: i32 = 0x40;
 const ELEVATION_SCALE: i32 = 0x10; // 16 units per elevation level
 
 impl ZTWorldMgr {
+    pub fn zoom_level(&self) -> i32 {
+        self.zoom_level
+    }
+
+    pub fn set_zoom_level(&mut self, zoom_level: i32) {
+        self.zoom_level = zoom_level;
+    }
+
     /// Get the start of the entity array in memory
     pub fn entity_array_start(&self) -> u32 {
         self.entity_array_start
@@ -387,6 +597,46 @@ impl ZTWorldMgr {
 }
 
 #[detour_mod]
+pub mod hooks_ztunit {
+    use super::*;
+
+    use crate::util::save_to_memory;
+    use openzt_detour::generated::ztunit::GET_FOOTPRINT;
+
+    #[detour(GET_FOOTPRINT)]
+    unsafe extern "thiscall" fn ztunit_get_footprint(_this: *const u32, param_1: *const u32, use_map_footprint: bool) -> *const u32 {
+        let entity = unsafe { ref_from_memory::<ZTUnit>(_this) };
+        let footprint: IVec3 = entity.get_footprint(use_map_footprint);
+
+        save_to_memory(param_1 as u32, footprint.x);
+        save_to_memory(param_1 as u32 + 0x4, footprint.y);
+        save_to_memory(param_1 as u32 + 0x8, footprint.z);
+
+        param_1
+    }
+}
+
+#[detour_mod]
+pub mod hooks_ztanimal {
+    use super::*;
+
+    use crate::util::save_to_memory;
+    use openzt_detour::generated::ztanimal::GET_FOOTPRINT;
+
+    #[detour(GET_FOOTPRINT)]
+    unsafe extern "thiscall" fn ztanimal_get_footprint(_this: *const u32, param_1: *const u32, use_map_footprint: bool) -> *const u32 {
+        let entity = unsafe { ref_from_memory::<ZTAnimal>(_this) };
+        let footprint: IVec3 = entity.get_footprint(use_map_footprint);
+
+        save_to_memory(param_1 as u32, footprint.x);
+        save_to_memory(param_1 as u32 + 0x4, footprint.y);
+        save_to_memory(param_1 as u32 + 0x8, footprint.z);
+
+        param_1
+    }
+}
+
+#[detour_mod]
 pub mod hooks_ztworldmgr {
     use crate::util::save_to_memory;
     use openzt_detour::generated::bfentity::{GET_BLOCKING_RECT, GET_BLOCKING_RECT_VIRT_ZTPATH, GET_FOOTPRINT, IS_ON_TILE};
@@ -395,7 +645,7 @@ pub mod hooks_ztworldmgr {
     use super::*;
 
     #[detour(GET_NEIGHBOR_1)]
-    unsafe extern "thiscall" fn bfmap_get_neighbour(_this: u32, bftile: u32, direction: u32) -> u32 {
+    unsafe extern "thiscall" fn bfmap_get_neighbour(_this: *const u32, bftile: *const u32, direction: u32) -> u32 {
         let ztwm = globals().ztworldmgr();
         let bftile = unsafe { ref_from_memory::<BFTile>(bftile) };
         let direction = Direction::from(direction);
@@ -407,35 +657,35 @@ pub mod hooks_ztworldmgr {
 
     // 0x0040f916 int * __thiscall OOAnalyzer::BFEntity::getFootprint(BFEntity *this,undefined4 *param_1)
     #[detour(GET_FOOTPRINT)]
-    unsafe extern "thiscall" fn bfentity_get_footprint(_this: u32, param_1: u32, _param_2: bool) -> u32 {
+    unsafe extern "thiscall" fn bfentity_get_footprint(_this: *const u32, param_1: *const u32, use_map_footprint: bool) -> *const u32 {
         let entity = unsafe { ref_from_memory::<BFEntity>(_this) };
-        let footprint = entity.get_footprint();
-        save_to_memory(param_1, footprint.x);
-        save_to_memory(param_1 + 0x4, footprint.y);
-        save_to_memory(param_1 + 0x8, footprint.z);
+        let footprint: IVec3 = entity.get_footprint(use_map_footprint);
+        save_to_memory(param_1 as u32, footprint.x);
+        save_to_memory(param_1 as u32 + 0x4, footprint.y);
+        save_to_memory(param_1 as u32 + 0x8, footprint.z);
 
         param_1
     }
 
     // 0x0042721a u32 __thiscall OOAnalyzer::BFEntity::getBlockingRect(BFEntity *this,u32 param_1)
     #[detour(GET_BLOCKING_RECT)]
-    unsafe extern "thiscall" fn bfentity_get_blocking_rect(_this: u32, param_1: u32) -> u32 {
+    unsafe extern "thiscall" fn bfentity_get_blocking_rect(_this: *const u32, param_1: *const i32) -> *const u32 {
         let entity = unsafe { ref_from_memory::<BFEntity>(_this) };
         save_to_memory(param_1, entity.get_blocking_rect());
-        param_1
+        param_1 as *const u32
     }
 
     // 0x004fbbee u32 __thiscall OOAnalyzer::BFEntity::getBlockingRect(BFEntity *this,u32 param_1)
     #[detour(GET_BLOCKING_RECT_VIRT_ZTPATH)]
-    unsafe extern "thiscall" fn bfentity_get_blocking_rect_ztpath(_this: u32, param_1: u32) -> u32 {
+    unsafe extern "thiscall" fn bfentity_get_blocking_rect_ztpath(_this: *const u32, param_1: *const i32) -> *const u32 {
         let entity = unsafe { ref_from_memory::<BFEntity>(_this) };
         save_to_memory(param_1, entity.get_blocking_rect());
-        param_1
+        param_1 as *const u32
     }
 
     // // 0040f26c BFPos * __thiscall OOAnalyzer::BFMap::tileToWorld(BFMap *this,BFPos *param_1,BFPos *param_2,BFPos *param_3)
     #[detour(TILE_TO_WORLD)]
-    unsafe extern "thiscall" fn bfmap_tile_to_world(_this: u32, param_1: u32, param_2: u32, param_3: u32) -> u32 {
+    unsafe extern "thiscall" fn bfmap_tile_to_world(_this: *const u32, param_1: *const i32, param_2: *const i32, param_3: *const i32) -> *const i32 {
         let ztwm = globals().ztworldmgr();
         let tile_pos = get_from_memory::<IVec3>(param_2);
         let local_pos = get_from_memory::<IVec3>(param_3);
@@ -447,7 +697,7 @@ pub mod hooks_ztworldmgr {
     // TODO: Remove this when check_tank_placement is fully implemented
     // 004e16f1 bool __thiscall OOAnalyzer::BFEntity::isOnTile(BFEntity *this,BFTile *param_1)
     #[detour(IS_ON_TILE)]
-    unsafe extern "thiscall" fn bfentity_is_on_tile(_this: u32, param_1: u32) -> bool {
+    unsafe extern "thiscall" fn bfentity_is_on_tile(_this: *const u32, param_1: *const u32) -> bool {
         let result = unsafe { IS_ON_TILE_DETOUR.call(_this, param_1) };
         let entity = unsafe { ref_from_memory::<BFEntity>(_this) };
         let tile = unsafe { ref_from_memory::<BFTile>(param_1) };
@@ -463,13 +713,16 @@ pub mod hooks_ztworldmgr {
 }
 
 pub fn init() {
-    // list_entities() - no args
-    lua_fn!("list_entities", "Lists all entities in the world", "list_entities()", || {
-        match command_get_zt_world_mgr_entities(vec![]) {
-            Ok(result) => Ok((Some(result), None::<String>)),
-            Err(e) => Ok((None::<String>, Some(e.to_string()))),
+    // list_entities([entity_type]) - optional arg
+    lua_fn!("list_entities", "Lists all entities in the world", "list_entities([entity_type])",
+        |entity_type: Option<String>| {
+            let args = entity_type.as_ref().map(|s| vec![s.as_str()]).unwrap_or_default();
+            match command_get_zt_world_mgr_entities(args) {
+                Ok(result) => Ok((Some(result), None::<String>)),
+                Err(e) => Ok((None::<String>, Some(e.to_string()))),
+            }
         }
-    });
+    );
 
     // list_entities_2() - no args
     lua_fn!("list_entities_2", "Lists all entities in the world (alternate format)", "list_entities_2()", || {
@@ -478,6 +731,28 @@ pub fn init() {
             Err(e) => Ok((None::<String>, Some(e.to_string()))),
         }
     });
+
+    // read_entity_offset(offsets..., types..., [entity_type]) - offsets (1 or more), types (1 or same count as offsets), optional entity type filter
+    lua_fn!("read_entity_offset", "Read value(s) at offset(s) from entities. Offsets: one or more. Types: one (applied to all) or same count as offsets. Optional: entity_type filter. (types: ptr, u32, i32, u16, i16, u8, i8, f32, bool)", "read_entity_offset(offsets..., [types...], [entity_type])",
+        |args: mlua::Variadic<String>| {
+            let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+            match command_read_entity_offset(str_args) {
+                Ok(result) => Ok((Some(result), None::<String>)),
+                Err(e) => Ok((None::<String>, Some(e.to_string()))),
+            }
+        }
+    );
+
+    // read_entity_type_offset(offsets..., types..., [entity_type_class]) - offsets (1 or more), types (1 or same count as offsets), optional entity type class filter
+    lua_fn!("read_entity_type_offset", "Read value(s) at offset(s) from entity types. Offsets: one or more. Types: one (applied to all) or same count as offsets. Optional: entity_type_class filter. (types: ptr, u32, i32, u16, i16, u8, i8, f32, bool)", "read_entity_type_offset(offsets..., [types...], [entity_type_class])",
+        |args: mlua::Variadic<String>| {
+            let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+            match command_read_entity_type_offset(str_args) {
+                Ok(result) => Ok((Some(result), None::<String>)),
+                Err(e) => Ok((None::<String>, Some(e.to_string()))),
+            }
+        }
+    );
 
     // list_types() - no args
     lua_fn!("list_types", "Lists all entity types in the world", "list_types()", || {
@@ -529,7 +804,11 @@ pub fn init() {
         }
     );
 
-    unsafe { hooks_ztworldmgr::init_detours().unwrap() };
+    unsafe {
+        hooks_ztworldmgr::init_detours().unwrap();
+        hooks_ztunit::init_detours().unwrap();
+        hooks_ztanimal::init_detours().unwrap();
+    };
 }
 
 pub fn read_zt_entity_from_memory(zt_entity_ptr: u32) -> ZTEntity {
@@ -550,16 +829,274 @@ fn log_zt_world_mgr(zt_world_mgr: &ZTWorldMgr) {
     info!("zt_world_mgr: {:#?}", zt_world_mgr);
 }
 
-fn command_get_zt_world_mgr_entities(_args: Vec<&str>) -> Result<String, CommandError> {
+fn command_get_zt_world_mgr_entities(args: Vec<&str>) -> Result<String, CommandError> {
+    let filter = if args.len() > 1 {
+        return Err(CommandError::new("Too many arguments".to_string()));
+    } else if args.len() == 1 {
+        Some(args[0].parse::<ZTEntityClass>().map_err(|e| CommandError::new(e))?)
+    } else {
+        None
+    };
+
     let zt_world_mgr = globals().ztworldmgr();
     let entities = get_zt_world_mgr_entities(zt_world_mgr);
-    info!("Found {} entities", entities.len());
-    if entities.is_empty() {
+
+    let filtered: Vec<_> = if let Some(ref entity_type) = filter {
+        entities.iter().filter(|e| e.entity.class == *entity_type).collect()
+    } else {
+        entities.iter().collect()
+    };
+
+    info!("Found {} entities (filtered from {})", filtered.len(), entities.len());
+    if filtered.is_empty() {
         return Ok("No entities found".to_string());
     }
+
     let mut string_array = Vec::new();
-    for entity in entities {
-        string_array.push(entity.to_string());
+    for ewp in filtered {
+        string_array.push(ewp.entity.to_string());
+    }
+    Ok(string_array.join("\n"))
+}
+
+// Helper struct for offset reads
+#[derive(Clone)]
+struct OffsetRead {
+    offset: u32,
+    type_str: String,
+}
+
+// Helper function to parse offset and type strings into OffsetRead structs
+fn parse_offset_reads(
+    offset_strs: &[&str],
+    type_strs: &[&str],
+    valid_types: &[&str],
+) -> Result<Vec<OffsetRead>, CommandError> {
+    if offset_strs.is_empty() {
+        return Err(CommandError::new("At least one offset must be provided".to_string()));
+    }
+
+    // Parse offsets
+    let mut offsets: Vec<u32> = Vec::new();
+    for offset_str in offset_strs {
+        let offset = match offset_str.strip_prefix("0x") {
+            Some(hex_str) => u32::from_str_radix(hex_str, 16).map_err(|e| CommandError::new(format!("Invalid offset '{}': {}", offset_str, e)))?,
+            None => offset_str.parse::<u32>().map_err(|e| CommandError::new(format!("Invalid offset '{}': {}", offset_str, e)))?,
+        };
+        offsets.push(offset);
+    }
+
+    // Validate types
+    for type_str in type_strs {
+        if !valid_types.contains(type_str) {
+            return Err(CommandError::new(format!("Invalid type '{}'. Valid types: {}", type_str, valid_types.join(", "))));
+        }
+    }
+
+    // Create OffsetRead structs
+    let mut offset_reads: Vec<OffsetRead> = Vec::new();
+    match type_strs.len() {
+        0 => {
+            // Default type "u32" for all offsets
+            for offset in offsets {
+                offset_reads.push(OffsetRead { offset, type_str: "u32".to_string() });
+            }
+        }
+        1 => {
+            // Single type applies to all offsets
+            let type_str = type_strs[0].to_string();
+            for offset in offsets {
+                offset_reads.push(OffsetRead { offset, type_str: type_str.clone() });
+            }
+        }
+        n if n == offsets.len() => {
+            // One type per offset
+            for (i, offset) in offsets.into_iter().enumerate() {
+                offset_reads.push(OffsetRead { offset, type_str: type_strs[i].to_string() });
+            }
+        }
+        n => {
+            return Err(CommandError::new(format!(
+                "Type count ({}) must be 1 or match offset count ({})",
+                n, offsets.len()
+            )));
+        }
+    }
+
+    Ok(offset_reads)
+}
+
+// Helper function to parse variadic args into (offsets, types, filter)
+fn parse_offset_type_filter_args<'a>(
+    args: &'a [&'a str],
+    valid_types: &[&str],
+) -> Result<(Vec<&'a str>, Vec<&'a str>, Option<&'a str>), CommandError> {
+    if args.is_empty() {
+        return Err(CommandError::new("At least one offset must be provided".to_string()));
+    }
+
+    // Find where types start (first valid type string)
+    let mut types_start_idx = args.len();
+    for (i, arg) in args.iter().enumerate() {
+        // Skip first arg (must be an offset)
+        if i == 0 {
+            continue;
+        }
+        if valid_types.contains(arg) {
+            types_start_idx = i;
+            break;
+        }
+    }
+
+    // Check if last arg is entity type filter (not a valid type)
+    let (offset_strs, type_strs, filter): (&[&str], &[&str], Option<&str>) = if types_start_idx < args.len() {
+        // Found type(s)
+        let offset_strs = &args[0..types_start_idx];
+        let remaining = &args[types_start_idx..];
+
+        // Check if last arg is entity type filter (not a valid type)
+        if remaining.len() > 1 && !valid_types.contains(remaining.last().unwrap()) {
+            let type_strs = &remaining[..remaining.len() - 1];
+            let filter = Some(*remaining.last().unwrap());
+            (offset_strs, type_strs, filter)
+        } else {
+            let type_strs = remaining;
+            (offset_strs, type_strs, None)
+        }
+    } else {
+        // No types provided, check if last arg is entity type filter
+        let offset_strs = &args[0..args.len()];
+        if offset_strs.len() > 1 && !valid_types.contains(offset_strs.last().unwrap()) {
+            // Last arg might be filter
+            let (offsets, filter) = offset_strs.split_at(offset_strs.len() - 1);
+            (offsets, &[].as_slice(), Some(filter[0]))
+        } else {
+            (offset_strs, &[].as_slice(), None)
+        }
+    };
+
+    Ok((offset_strs.to_vec(), type_strs.to_vec(), filter))
+}
+
+fn command_read_entity_offset(args: Vec<&str>) -> Result<String, CommandError> {
+    let valid_types = ["ptr", "u32", "i32", "u16", "i16", "u8", "i8", "f32", "bool"];
+
+    // Parse: offsets..., [types...], [entity_type]
+    let (offset_strs, type_strs, filter) = parse_offset_type_filter_args(&args, &valid_types)?;
+
+    let offset_reads = parse_offset_reads(&offset_strs, &type_strs, &valid_types)?;
+
+    // Parse entity type filter
+    let filter = if let Some(filter_str) = filter {
+        Some(filter_str.parse::<ZTEntityClass>().map_err(|e| CommandError::new(e))?)
+    } else {
+        None
+    };
+
+    let zt_world_mgr = globals().ztworldmgr();
+    let entities = get_zt_world_mgr_entities(zt_world_mgr);
+
+    let filtered: Vec<_> = if let Some(ref entity_type) = filter {
+        entities.iter().filter(|e| e.entity.class == *entity_type).collect()
+    } else {
+        entities.iter().collect()
+    };
+
+    if filtered.is_empty() {
+        return Ok("No entities found".to_string());
+    }
+
+    let mut string_array = Vec::new();
+    for ewp in filtered {
+        let mut parts = vec![
+            format!("{:#x}", ewp.ptr),
+            ewp.entity.name.clone()
+        ];
+
+        if filter.is_none() {
+            parts.push(format!("{:?}", ewp.entity.class));
+        }
+
+        // Read each offset
+        for read in &offset_reads {
+            let value_str = match read.type_str.as_str() {
+                "ptr" => format!("{:#x}", get_from_memory::<u32>(ewp.ptr + read.offset)),
+                "u32" => format!("{}", get_from_memory::<u32>(ewp.ptr + read.offset)),
+                "i32" => format!("{}", get_from_memory::<i32>(ewp.ptr + read.offset)),
+                "u16" => format!("{}", get_from_memory::<u16>(ewp.ptr + read.offset)),
+                "i16" => format!("{}", get_from_memory::<i16>(ewp.ptr + read.offset)),
+                "u8" => format!("{}", get_from_memory::<u8>(ewp.ptr + read.offset)),
+                "i8" => format!("{}", get_from_memory::<i8>(ewp.ptr + read.offset)),
+                "f32" => format!("{}", get_from_memory::<f32>(ewp.ptr + read.offset)),
+                "bool" => format!("{}", get_from_memory::<bool>(ewp.ptr + read.offset)),
+                _ => unreachable!(),
+            };
+            parts.push(format!("{}", value_str));
+        }
+
+        string_array.push(parts.join(" | "));
+    }
+    Ok(string_array.join("\n"))
+}
+
+fn command_read_entity_type_offset(args: Vec<&str>) -> Result<String, CommandError> {
+    let valid_types = ["ptr", "u32", "i32", "u16", "i16", "u8", "i8", "f32", "bool"];
+
+    // Parse: offsets..., [types...], [entity_type_class]
+    let (offset_strs, type_strs, filter) = parse_offset_type_filter_args(&args, &valid_types)?;
+
+    let offset_reads = parse_offset_reads(&offset_strs, &type_strs, &valid_types)?;
+
+    // Parse entity type class filter
+    let filter = if let Some(filter_str) = filter {
+        Some(filter_str.parse::<ZTEntityTypeClass>().map_err(|e| CommandError::new(e))?)
+    } else {
+        None
+    };
+
+    let zt_world_mgr = globals().ztworldmgr();
+    let entity_types = get_zt_world_mgr_types(zt_world_mgr);
+
+    let filtered: Vec<_> = if let Some(ref entity_type_class) = filter {
+        entity_types.iter().filter(|et| et.entity_type.class == *entity_type_class).collect()
+    } else {
+        entity_types.iter().collect()
+    };
+
+    if filtered.is_empty() {
+        return Ok("No entity types found".to_string());
+    }
+
+    let mut string_array = Vec::new();
+    for etwp in filtered {
+        let mut parts = vec![
+            format!("{:#x}", etwp.ptr),
+            etwp.entity_type.zt_type.clone(),
+            etwp.entity_type.zt_sub_type.clone()
+        ];
+
+        if filter.is_none() {
+            parts.push(format!("{:?}", etwp.entity_type.class));
+        }
+
+        // Read each offset
+        for read in &offset_reads {
+            let value_str = match read.type_str.as_str() {
+                "ptr" => format!("{:#x}", get_from_memory::<u32>(etwp.ptr + read.offset)),
+                "u32" => format!("{}", get_from_memory::<u32>(etwp.ptr + read.offset)),
+                "i32" => format!("{}", get_from_memory::<i32>(etwp.ptr + read.offset)),
+                "u16" => format!("{}", get_from_memory::<u16>(etwp.ptr + read.offset)),
+                "i16" => format!("{}", get_from_memory::<i16>(etwp.ptr + read.offset)),
+                "u8" => format!("{}", get_from_memory::<u8>(etwp.ptr + read.offset)),
+                "i8" => format!("{}", get_from_memory::<i8>(etwp.ptr + read.offset)),
+                "f32" => format!("{}", get_from_memory::<f32>(etwp.ptr + read.offset)),
+                "bool" => format!("{}", get_from_memory::<bool>(etwp.ptr + read.offset)),
+                _ => unreachable!(),
+            };
+            parts.push(format!("offset{:#x}={}", read.offset, value_str));
+        }
+
+        string_array.push(parts.join(" | "));
     }
     Ok(string_array.join("\n"))
 }
@@ -596,7 +1133,7 @@ fn command_get_entity_unique_vtable_entries(args: Vec<&str>) -> Result<String, C
 
     entities
         .iter()
-        .map(|entity| (entity.type_class.class.clone(), entity.vtable + vtable_offset))
+        .map(|ewp| (ewp.entity.type_class.class.clone(), ewp.entity.vtable + vtable_offset))
         .unique_by(|t| t.1)
         .for_each(|(type_name, vfunc_ptr)| {
             result.push_str(&format!("{:?} -> {:#x}\n", type_name, get_from_memory::<u32>(vfunc_ptr)));
@@ -616,13 +1153,13 @@ fn command_get_entity_type_unique_vtable_entries(args: Vec<&str>) -> Result<Stri
     };
 
     let zt_world_mgr = globals().ztworldmgr();
-    let entities = get_zt_world_mgr_types(zt_world_mgr);
+    let entity_types = get_zt_world_mgr_types(zt_world_mgr);
 
     let mut result = String::new();
 
-    entities
+    entity_types
         .iter()
-        .map(|entity_type| (entity_type.class.clone(), entity_type.vtable + vtable_offset))
+        .map(|etwp| (etwp.entity_type.class.clone(), etwp.entity_type.vtable + vtable_offset))
         .unique_by(|t| t.1)
         .for_each(|(type_name, vfunc_ptr)| {
             result.push_str(&format!("{:?} -> {:#x}\n", type_name, get_from_memory::<u32>(vfunc_ptr)));
@@ -639,8 +1176,8 @@ fn command_get_zt_world_mgr_types(_args: Vec<&str>) -> Result<String, CommandErr
         return Ok("No types found".to_string());
     }
     let mut string_array = Vec::new();
-    for zt_type in types {
-        string_array.push(zt_type.to_string());
+    for etwp in types {
+        string_array.push(etwp.entity_type.to_string());
     }
     Ok(string_array.join("\n"))
 }
@@ -658,9 +1195,9 @@ fn command_zt_world_mgr_types_summary(_args: Vec<&str>) -> Result<String, Comman
     if types.is_empty() {
         return Ok("No types found".to_string());
     }
-    let mut current_class = types[0].class.clone();
-    for zt_type in types {
-        if current_class != zt_type.class {
+    let mut current_class = types[0].entity_type.class.clone();
+    for etwp in types {
+        if current_class != etwp.entity_type.class {
             let mut string_array = Vec::new();
             let mut total = 0;
             for (class, count) in subtype {
@@ -670,24 +1207,25 @@ fn command_zt_world_mgr_types_summary(_args: Vec<&str>) -> Result<String, Comman
             summary.push_str(&format!("{:?}: ({})\n{}\n", current_class, total, string_array.join("\n")));
             info!("{:?}: ({})\n{}", current_class, total, string_array.join("\n"));
             subtype = HashMap::new();
-            current_class = zt_type.class.clone();
+            current_class = etwp.entity_type.class.clone();
         }
-        info!("{:?}, {}", current_class, zt_type.zt_type);
-        let count = subtype.entry(zt_type.zt_type).or_insert(0);
+        info!("{:?}, {}", current_class, etwp.entity_type.zt_type);
+        let count = subtype.entry(etwp.entity_type.zt_type.clone()).or_insert(0);
         *count += 1;
     }
     Ok(summary)
 }
 
-fn get_zt_world_mgr_entities(zt_world_mgr: &ZTWorldMgr) -> Vec<ZTEntity> {
+fn get_zt_world_mgr_entities(zt_world_mgr: &ZTWorldMgr) -> Vec<ZTEntityWithPtr> {
     let entity_array_start = zt_world_mgr.entity_array_start;
     let entity_array_end = zt_world_mgr.entity_array_end;
 
-    let mut entities: Vec<ZTEntity> = Vec::new();
+    let mut entities: Vec<ZTEntityWithPtr> = Vec::new();
     let mut i = entity_array_start;
     while i < entity_array_end {
-        let zt_entity = read_zt_entity_from_memory(get_from_memory::<u32>(i));
-        entities.push(zt_entity);
+        let entity_ptr = get_from_memory::<u32>(i);
+        let zt_entity = read_zt_entity_from_memory(entity_ptr);
+        entities.push(ZTEntityWithPtr { ptr: entity_ptr, entity: zt_entity });
         i += 0x4;
     }
     entities
@@ -707,16 +1245,17 @@ fn get_zt_world_mgr_entities_2(zt_world_mgr: &ZTWorldMgr) -> Vec<BFEntity> {
     entities
 }
 
-fn get_zt_world_mgr_types(zt_world_mgr: &ZTWorldMgr) -> Vec<ZTEntityType> {
+fn get_zt_world_mgr_types(zt_world_mgr: &ZTWorldMgr) -> Vec<ZTEntityTypeWithPtr> {
     let entity_type_array_start = zt_world_mgr.entity_type_array_start;
     let entity_type_array_end = zt_world_mgr.entity_type_array_end;
 
-    let mut entity_types: Vec<ZTEntityType> = Vec::new();
+    let mut entity_types: Vec<ZTEntityTypeWithPtr> = Vec::new();
     let mut i = entity_type_array_start;
     while i < entity_type_array_end {
-        info!("Reading entity at {:#x} -> {:#x}", i, get_from_memory::<u32>(i));
-        let zt_entity_type = read_zt_entity_type_from_memory(get_from_memory::<u32>(i));
-        entity_types.push(zt_entity_type);
+        let type_ptr = get_from_memory::<u32>(i);
+        info!("Reading entity at {:#x} -> {:#x}", i, type_ptr);
+        let zt_entity_type = read_zt_entity_type_from_memory(type_ptr);
+        entity_types.push(ZTEntityTypeWithPtr { ptr: type_ptr, entity_type: zt_entity_type });
         i += 0x4;
     }
     entity_types
@@ -740,7 +1279,8 @@ pub fn get_entity_type_by_id(id: u32) -> u32 {
     // let overlay_types: HashSet<&str> = ["Ambient"].iter().cloned().collect();
 
     while i > 0 {
-        let entity_type_ptr = entity_type_array_start + i * 0x4;
+        let array_entry = entity_type_array_start + i * 0x4;
+        let entity_type_ptr = get_from_memory::<u32>(array_entry);
         info!("Checking entity type at {:#x}", entity_type_ptr);
         let entity_type = map_from_memory::<ZTSceneryType>(entity_type_ptr);
         info!("Entity type name id: {}", entity_type.name_id);


### PR DESCRIPTION
Reimplements ZTMapView::checkTankPlacement with real validation logic (entity class checks, tank height, avoid-edges, show-tank matching), plus the entity/habitat struct layout corrections and generated.rs signature retypes it depends on: BFEntity/ZTUnit/ZTAnimal hierarchy, ZTHabitat tank fields, BFTile fence pointers, and debug console commands for reading arbitrary entity/entity-type offsets.
