### PR TITLE
Switch to Rust data structures and reimplement ZTAwardMgr

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -472,6 +472,124 @@ For features not covered by integration tests:
 3. Test console commands if applicable
 4. Check for game crashes or memory issues
 
+## Reimplementation Pattern
+
+This section documents how a vanilla `ZT*Mgr`/`BF*Mgr` class gets fully reimplemented in Rust (see
+`openzt/plans/zt-mgr-classes-reimplementation-roadmap.md` for which classes are done/candidates). Established
+by `ztmarketing.rs`/`ztresearch.rs`/`ztthoughtmgr.rs`/`ztmegatilemgr.rs`.
+
+### `openzt-detour/src/generated.rs`
+
+- Auto-generated from a Ghidra analysis pass run **outside this repo** - there is no generator script checked
+  in. **Never hand-patch this file's existing entries** - a regeneration silently discards hand-edits. The one
+  sanctioned exception is adding an entry for a function Ghidra's pass hasn't picked up yet: add it inside the
+  relevant `pub mod <classname> { ... }` block with a `// Hand-added: <reason>` comment directly above it,
+  matching the existing hand-added block's style (search the file for `Hand-added` to find the precedent).
+- One `pub mod <lowercase_classname> { ... }` block per C++ class (free functions live under `standalone` or a
+  UI-area module like `ztui`). Each function is `pub const <SCREAMING_NAME>: FunctionDef<unsafe extern
+  "<abi>" fn(...) -> R> = FunctionDef{address: 0x..., function_type: PhantomData};`.
+- `address` is always the **raw Ghidra virtual address, untouched** - Zoo Tycoon's `.exe` has no ASLR and
+  always loads at its preferred base `0x00400000`, so a Ghidra VA already equals the runtime VA for *code*.
+  This is different from **data** addresses (globals/statics), which get resolved at runtime as
+  `get_module_base("zoo.exe") + RVA` (RVA = Ghidra address minus `0x400000`) - see `globals.rs`'s
+  `CachedGlobalInstance` entries for the pattern. Don't confuse the two: function-table entries in
+  `generated.rs` need no base-address math; ad-hoc global/struct-field addresses computed in `openzt/src` do.
+- Every entry carries a `#[cfg_attr(feature = "detour-validation", validate_detour("class/method"))]`
+  attribute. This is currently inert scaffolding - no `detour-validation` feature or `validate_detour` macro
+  exists in the repo - just copy the attribute verbatim on any new entry for consistency, don't try to wire it
+  up.
+- `FunctionDef::original()` returns the real vanilla function unconditionally (`retour::Function::from_ptr` on
+  the stored address) - it does **not** check whether that address is currently hooked. Calling `.original()`
+  on a function you have *not* detoured is always safe. Calling it *from inside that same function's own
+  detour* is not (see below).
+
+### Detouring a function (`#[detour_mod]` / `#[detour(NAME)]`)
+
+Provided by `openzt-detour-macro`. Shape (see `ztthoughtmgr.rs`'s `thought_save_detours` module or
+`ztmegatilemgr.rs`'s `megatilemgr_detours` module for full worked examples):
+
+```rust
+use openzt_detour::generated::<classname>::{SAVE, LOAD};
+
+#[detour_mod]
+mod detours {
+    use super::*;
+    #[detour(SAVE)]
+    unsafe extern "thiscall" fn save(this: *const u32, file: *const u32) -> bool {
+        unsafe { ref_from_memory::<MyMgr>(this) }.save(file)
+    }
+}
+
+pub fn init() {
+    if let Err(e) = unsafe { detours::init_detours() } {
+        error!("Failed to initialise <classname> detours: {e:?}");
+    }
+}
+```
+
+- `#[detour_mod]` generates one `static <NAME>_DETOUR: LazyLock<GenericDetour<...>> = ...` per `#[detour(NAME)]`
+  function in the block, plus an `init_detours()` that `.enable()`s each. The detour function's own
+  `extern "<abi>"` annotation is read directly by the macro and must match the `FunctionDef`'s ABI/signature
+  exactly - there's no separate thiscall-specific wrapper, just Rust's native `extern "thiscall"` support with
+  `this: *const u32` as the first parameter.
+- Use `NAME.original()(...)` to call a vanilla function's real body when you have **not** hooked that same
+  function (e.g. calling a different helper, or calling through from one class's detour into another
+  class's un-hooked method).
+- Use the macro-generated `<NAME>_DETOUR.call(...)` only when calling the real body **of the function your
+  current code is itself a detour for** (its address has been patched to jump into your detour, so
+  `.original()` there would recurse into yourself). See `resource_manager/hooks.rs`'s `CONSTRUCTOR` detour for
+  the pattern (run `CONSTRUCTOR_DETOUR.call(this_ptr)` first, then layer additional Rust logic on top).
+- A **partial-override** detour (replace behavior for one input/condition, delegate to the real function for
+  everything else) uses the same `<NAME>_DETOUR.call(...)` mechanism inside a `match`/`if` - see
+  `resource_manager/hooks.rs`'s `zoo_ui_general_get_info_image_name` for the shape. There's no dedicated
+  "partial override" macro - it's a plain conditional around the call-through.
+
+### File/module shape for a class reimplementation
+
+One file per class in `openzt/src/` (e.g. `ztthoughtmgr.rs`): module doc comment explaining the vanilla class
+and any allocator/memory-safety caveats -> `#[repr(C)]` struct(s) mirroring vanilla layout with a
+`size_of` assertion, **only if the reimplementation needs to read/write vanilla's own memory in place**
+(see "Two reimplementation styles" below) -> `impl` blocks with the real logic as plain Rust methods, kept
+separate from the detour glue -> one or more `#[detour_mod] mod ... { }` blocks (split into
+purpose-grouped submodules for a large class, e.g. `ztthoughtmgr.rs`'s `thought_accessor_detours`/
+`thought_mutator_detours`/`thought_save_detours`/`thought_dtor_detour`) -> a top-level `pub fn init()`
+aggregating each submodule's `init()` -> `#[cfg(feature = "reimplementation-tests")] pub(crate) mod
+live_support { ... }` with test-only helpers -> `#[cfg(test)] mod tests { ... }` for plain logic unit tests.
+
+Wire a new module into `lib.rs`: add `mod <name>;` near the other `mod zt*mgr;` declarations, and
+`<name>::init();` inside the `if cfg!(feature = "experimental") { ... }` block.
+
+### Two reimplementation styles - pick based on whether other vanilla code reads the class's raw memory
+
+1. **Vanilla-layout-compatible** (`ZTThoughtMgr`, `ZTMegatileMgr`): the global is a pointer to a
+   heap-allocated instance; a `#[repr(C)]` struct mirrors vanilla's fields exactly, and Rust methods read/write
+   that memory in place (sometimes alongside a side `HashMap` keyed by pointer for data that doesn't fit
+   vanilla's layout). Necessary when other, un-decompiled/un-detoured vanilla code might still read the
+   struct's raw fields directly (can't fully rule this out), or when the global is heap-allocated via a
+   constructor that can also be run against a fresh allocation for standalone side-by-side testing.
+2. **Fully independent Rust store** (no vanilla-layout struct at all): only viable when every vanilla code
+   path that reads/writes the class's fields has been enumerated (grep the whole decompile corpus for the
+   class name *and* the raw field addresses directly, not just method names - a caller can read a field
+   inline without going through any method call) and every one of them is being detoured/reimplemented too.
+   Vanilla's own copy of the data is then left completely alone (never read or written by Rust) and becomes
+   inert dead weight. This sidesteps the cross-allocator hazard below entirely, at the cost of losing the
+   ability to do standalone/side-by-side memory-diff testing if the class's constructor hardcodes a fixed
+   global address (can't be run against a second instance) - live tests then have to compare `.original()`
+   *behavior/return values* against the Rust store's outputs instead of diffing shared memory.
+
+### Cross-allocator memory safety (style 1 only)
+
+**Never free real vanilla-allocated output through Rust's allocator, or vice versa.** If a class manages its
+own heap objects reachable through a still-live, undetoured vanilla code path (e.g. a linked list node
+allocated through vanilla's own small-object freelist when reached via `.original()`, vs. a `Box` when built
+by test/reimplementation code), calling `Box::from_raw`/`drop` on a vanilla-allocated node - or letting
+vanilla's own free path touch a `Box`-allocated node - is genuine heap corruption, not just a leak. It can
+crash, but Windows' Fault Tolerant Heap may silently absorb a few occurrences (no dialog, empty `openzt.log`,
+looks like the game "just exited") - a reboot is sometimes needed to see a real crash again once FTH kicks in.
+Build a leak-only teardown path for the side that might hold vanilla-allocated nodes (free only what your own
+code definitely allocated, deliberately leak the rest) rather than reusing a normal Box-walking cleanup - see
+`ztthoughtmgr.rs`'s `live_support::destroy_standalone_mgr_leaking_nodes` for a worked example.
+
 ## Code Quality
 
 - Avoid obvious comments that restate code

--- a/openzt-detour/src/generated.rs
+++ b/openzt-detour/src/generated.rs
@@ -5909,6 +5909,17 @@ pub mod ztguest {
     pub const DRAW_AIINFO: FunctionDef<unsafe extern "thiscall" fn(*const u32, *const u32, i32, i32, i32)> = FunctionDef{address: 0x00619050, function_type: PhantomData};
     #[cfg_attr(feature = "detour-validation", validate_detour("ztguest/do_happy_price_change"))]
     pub const DO_HAPPY_PRICE_CHANGE: FunctionDef<unsafe extern "thiscall" fn(*const u32)> = FunctionDef{address: 0x00619245, function_type: PhantomData};
+    // Hand-added: no Windows decompile exists for these three (nor for their sole caller,
+    // doEnvironmentEffectCheck) - confirmed by direct disassembly of zoo.dll instead. See
+    // private/docs/vtables/ZTGuest.md's "Non-virtual confirmed methods" section for the evidence.
+    #[cfg_attr(feature = "detour-validation", validate_detour("ztguest/f_crowd_density_megatile"))]
+    pub const F_CROWD_DENSITY_MEGATILE: FunctionDef<unsafe extern "thiscall" fn(*const u32) -> i32> = FunctionDef{address: 0x0043b7e3, function_type: PhantomData};
+    #[cfg_attr(feature = "detour-validation", validate_detour("ztguest/f_esthetic_bonus_megatile"))]
+    pub const F_ESTHETIC_BONUS_MEGATILE: FunctionDef<unsafe extern "thiscall" fn(*const u32) -> f32> = FunctionDef{address: 0x0043b6c0, function_type: PhantomData};
+    #[cfg_attr(feature = "detour-validation", validate_detour("ztguest/f_stinky_megatile"))]
+    pub const F_STINKY_MEGATILE: FunctionDef<unsafe extern "thiscall" fn(*const u32) -> f32> = FunctionDef{address: 0x0043b84a, function_type: PhantomData};
+    /// `doEnvironmentEffectCheck` - the sole caller of the three above, docs-only (not detoured).
+    pub const DO_ENVIRONMENT_EFFECT_CHECK: FunctionDef<unsafe extern "thiscall" fn(*const u32)> = FunctionDef{address: 0x0043abac, function_type: PhantomData};
 }
 
 // ZTGuestType class functions

--- a/openzt/src/lib.rs
+++ b/openzt/src/lib.rs
@@ -93,6 +93,14 @@ mod ztthoughtmgr;
 /// recalculate terrain "megatile" (5x5 tile block) guest-density/esthetic-bonus characteristics.
 mod ztmegatilemgr;
 
+/// ztawardmgr module has structs and methods for the vanilla ZTAwardMgr class, which tracks earned
+/// zoo-achievement awards and the award.cfg catalogue.
+mod ztawardmgr;
+
+/// ztguest module reimplements ZTGuest's three megatile-reading methods (fCrowdDensityMegatile/
+/// fEstheticBonusMegatile/fStinkyMegatile) - closes the last vanilla read path into ZTMegatileMgr's grid.
+mod ztguest;
+
 mod experimental;
 
 /// Roof tag extension for scenery entities
@@ -207,6 +215,8 @@ mod zoo_init {
             ztmarketing::init();
             ztthoughtmgr::init();
             ztmegatilemgr::init();
+            ztawardmgr::init();
+            ztguest::init();
         }
         unsafe { LOAD_LANG_DLLS_DETOUR.call(this) }
     }

--- a/openzt/src/reimplementation_tests/mod.rs
+++ b/openzt/src/reimplementation_tests/mod.rs
@@ -98,7 +98,9 @@ mod detour_zoo_main {
     use openzt_detour::generated::ztanimal::GET_FOOTPRINT as ZTANIMAL_GET_FOOTPRINT;
     use openzt_detour::generated::ztapp::UPDATE_SIM;
     use openzt_detour::generated::ztmarketing;
-    use openzt_detour::generated::ztmarketingmgr::{CLEAR_CONFIGURATIONS as ZTMARKETINGMGR_CLEAR_CONFIGURATIONS, LOAD_CONFIGURATIONS, UPDATE as ZTMARKETINGMGR_UPDATE};
+    use openzt_detour::generated::ztmarketingmgr::{
+        CLEAR_CONFIGURATIONS as ZTMARKETINGMGR_CLEAR_CONFIGURATIONS, LOAD_CONFIGURATIONS, UPDATE as ZTMARKETINGMGR_UPDATE, ZTMARKETING_MGR_1 as ZTMARKETINGMGR_DTOR,
+    };
     use openzt_detour::generated::ztresearchbranch;
     use openzt_detour::generated::ztresearchbranch::GET_FUNDING_TEXT as ZTRESEARCHBRANCH_GET_FUNDING_TEXT;
     use openzt_detour::generated::ztresearchbranch::UPDATE as ZTRESEARCHBRANCH_UPDATE;
@@ -109,6 +111,10 @@ mod detour_zoo_main {
     use openzt_detour::generated::ztthought as gen_ztthought;
     use openzt_detour::generated::ztthoughtmgr as gen_ztthoughtmgr;
     use openzt_detour::generated::ztmegatilemgr as gen_ztmegatilemgr;
+    use openzt_detour::generated::ztguest as gen_ztguest;
+    use openzt_detour::generated::ztawardmgr as gen_ztawardmgr;
+    use openzt_detour::generated::ztscenariosimplegoal::EVAL as ZTSCENARIOSIMPLEGOAL_EVAL;
+    use openzt_detour::generated::bfuimgr::GET_ELEMENT_0 as BFUIMGR_GET_ELEMENT_0;
     use openzt_detour::generated::zthabitatmgr;
     use openzt_detour::generated::ztui_gameopts::LOAD_FILE as ZTUI_GAMEOPTS_LOAD_FILE;
     use openzt_detour::generated::ztunit::GET_FOOTPRINT as ZTUNIT_GET_FOOTPRINT;
@@ -118,7 +124,7 @@ mod detour_zoo_main {
 
     use crate::{
         bfentitytype::{BFEntityType, ZTAnimalType, ZTUnitType},
-        globals::globals,
+        globals::{get_module_base, globals},
         util::{get_from_memory, save_to_memory, ZTBufferString, ZTString},
         zthabitatmgr::ZTHabitat,
         ztmapview::BFTile,
@@ -127,6 +133,8 @@ mod detour_zoo_main {
         ztresearch::{predict_branch_progress, predict_update, ZTResearchBranch, ZTResearchEffectKind, ZTResearchMgr},
         ztthoughtmgr::{live_support as thought_live_support, ZTThought, ZTThoughtMgr},
         ztmegatilemgr::live_support as megatile_live_support,
+        ztguest::{self, live_support as guest_live_support},
+        ztawardmgr::{self, live_support as award_live_support},
         ztworldmgr::{BFEntity, IVec3, ZTAnimal, ZTUnit},
     };
 
@@ -613,6 +621,7 @@ mod detour_zoo_main {
         fail_flag |= run_marketingmgr_save_test(&mut failure_log);
         fail_flag |= run_marketingmgr_load_test(&mut failure_log);
         fail_flag |= run_marketingmgr_clear_configurations_test(&mut failure_log);
+        fail_flag |= run_marketingmgr_dtor_test(&mut failure_log);
 
         fail_flag |= run_thoughtmgr_add_thought_test(&mut failure_log);
         fail_flag |= run_thoughtmgr_remove_thoughts_by_thinker_test(&mut failure_log);
@@ -623,6 +632,11 @@ mod detour_zoo_main {
         fail_flag |= run_thoughtmgr_get_thoughts_by_habitat_test(&mut failure_log);
         fail_flag |= run_thoughtmgr_save_test(&mut failure_log);
         fail_flag |= run_thoughtmgr_load_test(&mut failure_log);
+
+        fail_flag |= run_awardmgr_add_award_save_load_test(&mut failure_log);
+        fail_flag |= run_awardmgr_start_test(&mut failure_log);
+        fail_flag |= run_awardmgr_get_award_test(&mut failure_log);
+        fail_flag |= run_ztscenariosimplegoal_eval_award_count_test(&mut failure_log);
 
         // ZTRESEARCHMGR_SAVE: compares the real ZTResearchMgr::save's captured output against
         // research_save_reimplementation::serialize(&snapshot_mgr(mgr)) for generated synthetic trees.
@@ -1180,6 +1194,11 @@ mod detour_zoo_main {
             fail_flag |= run_megatilemgr_recalculate_characteristics_test(&mut failure_log);
             fail_flag |= run_megatile_category_map_layout_test(&mut failure_log);
             fail_flag |= run_megatilemgr_init_test(&mut failure_log);
+            fail_flag |= run_ztguest_megatile_methods_live_test(&mut failure_log);
+            // Re-run: the early-phase call above skips gracefully (GLOBAL_ZTGameMgr isn't initialized
+            // yet at that injection point) - retry now that run_load_live_zoo has guaranteed a live one.
+            fail_flag |= run_ztscenariosimplegoal_eval_award_count_test(&mut failure_log);
+            fail_flag |= run_awardmgr_show_awards_test(&mut failure_log);
         }
 
         if fail_flag {
@@ -1345,17 +1364,18 @@ mod detour_zoo_main {
         fail_flag
     }
 
-    /// Compares two megatile-grid snapshots allowing a small tolerance on the float fields
-    /// (`esthetic_bonus`) - real vanilla x87 arithmetic and Rust's SSE2 `f32` arithmetic can differ in
-    /// the last bit or two despite following the same formula, which isn't a meaningful mismatch for
-    /// this test. `guest_count` (an integer accumulation) is still compared exactly.
+    /// Compares two megatile-grid snapshots allowing a small tolerance on the float fields (`stink`,
+    /// formerly `esthetic_bonus` - see `ztmegatilemgr.rs`'s `ZTMegatile::stink`/finding 2) - real vanilla
+    /// x87 arithmetic and Rust's SSE2 `f32` arithmetic can differ in the last bit or two despite following
+    /// the same formula, which isn't a meaningful mismatch for this test. `guest_count` (an integer
+    /// accumulation) is still compared exactly.
     fn grids_approximately_equal(expected: &megatile_live_support::GridSnapshot, actual: &megatile_live_support::GridSnapshot) -> bool {
         if expected.columns.len() != actual.columns.len() {
             return false;
         }
         expected.columns.iter().zip(actual.columns.iter()).all(|(e_col, a_col)| {
             e_col.len() == a_col.len()
-                && e_col.iter().zip(a_col.iter()).all(|(&(e_guests, e_bonus), &(a_guests, a_bonus))| e_guests == a_guests && (e_bonus - a_bonus).abs() < 0.01)
+                && e_col.iter().zip(a_col.iter()).all(|(&(e_guests, e_stink), &(a_guests, a_stink))| e_guests == a_guests && (e_stink - a_stink).abs() < 0.01)
         })
     }
 
@@ -1487,6 +1507,75 @@ mod detour_zoo_main {
             write_success_line(failure_log, test_name);
         } else if let Some(log_file) = failure_log {
             let _ = log_file.write_all(format!("Test Failed {}\n", test_name).as_bytes());
+        }
+        fail_flag
+    }
+
+    /// ZTGUEST_MEGATILE_METHODS_LIVE: compares the real `ZTGuest::fCrowdDensityMegatile`/
+    /// `fStinkyMegatile`/`fEstheticBonusMegatile` (see `ztguest.rs`'s module doc comment for how these
+    /// three addresses were confirmed) against their Rust reimplementations, for *every* live guest
+    /// `guest_live_support::find_live_guests` finds on the loaded save - not just one, so the comparison
+    /// samples whatever spread of tiles/megatiles/entity-type category ids the live population actually
+    /// has, rather than a single arbitrary data point. Runs after the megatile-grid tests above so the
+    /// live singleton's grid is already in a real, recalculated state.
+    fn run_ztguest_megatile_methods_live_test(failure_log: &mut Option<std::fs::File>) -> bool {
+        let test_name = "ZTGUEST_MEGATILE_METHODS_LIVE";
+        let guests = guest_live_support::find_live_guests();
+        if guests.is_empty() {
+            write_success_line(failure_log, &format!("{} (skipped: no live guest found)", test_name));
+            return false;
+        }
+
+        let mut fail_flag = false;
+        let mut compared = 0usize;
+        for (guest_ptr, tile) in guests {
+            let this = guest_ptr as *const u32;
+            let entity = unsafe { crate::util::ref_from_memory::<BFEntity>(guest_ptr) };
+            compared += 1;
+
+            let real_crowd = unsafe { gen_ztguest::F_CROWD_DENSITY_MEGATILE.original()(this) };
+            let reimpl_crowd = ztguest::crowd_density_megatile(&tile);
+            if real_crowd != reimpl_crowd {
+                error!("{}: crowd density mismatch for guest {:#010x} at {}: real={}, reimpl={}", test_name, guest_ptr, tile, real_crowd, reimpl_crowd);
+                if let Some(log_file) = failure_log {
+                    let _ = log_file.write_all(
+                        format!("Test Failed {}: crowd density mismatch for guest {:#010x} at {}: real={}, reimpl={}\n", test_name, guest_ptr, tile, real_crowd, reimpl_crowd).as_bytes(),
+                    );
+                }
+                fail_flag = true;
+            }
+
+            let real_stink = unsafe { gen_ztguest::F_STINKY_MEGATILE.original()(this) };
+            let reimpl_stink = ztguest::stinky_megatile(&tile);
+            if (real_stink - reimpl_stink).abs() >= 0.01 {
+                error!("{}: stink mismatch for guest {:#010x} at {}: real={}, reimpl={}", test_name, guest_ptr, tile, real_stink, reimpl_stink);
+                if let Some(log_file) = failure_log {
+                    let _ = log_file.write_all(
+                        format!("Test Failed {}: stink mismatch for guest {:#010x} at {}: real={}, reimpl={}\n", test_name, guest_ptr, tile, real_stink, reimpl_stink).as_bytes(),
+                    );
+                }
+                fail_flag = true;
+            }
+
+            let real_esthetic = unsafe { gen_ztguest::F_ESTHETIC_BONUS_MEGATILE.original()(this) };
+            let reimpl_esthetic = ztguest::esthetic_bonus_megatile(entity, &tile);
+            if (real_esthetic - reimpl_esthetic).abs() >= 0.01 {
+                error!("{}: esthetic bonus mismatch for guest {:#010x} at {}: real={}, reimpl={}", test_name, guest_ptr, tile, real_esthetic, reimpl_esthetic);
+                if let Some(log_file) = failure_log {
+                    let _ = log_file.write_all(
+                        format!(
+                            "Test Failed {}: esthetic bonus mismatch for guest {:#010x} at {}: real={}, reimpl={}\n",
+                            test_name, guest_ptr, tile, real_esthetic, reimpl_esthetic
+                        )
+                        .as_bytes(),
+                    );
+                }
+                fail_flag = true;
+            }
+        }
+
+        if !fail_flag {
+            write_success_line(failure_log, &format!("{} ({} guests compared)", test_name, compared));
         }
         fail_flag
     }
@@ -2724,6 +2813,75 @@ mod detour_zoo_main {
         fail_flag
     }
 
+    /// ZTMARKETINGMGR_DTOR: verifies the fix for the real correctness bug `ztmarketing.rs`'s
+    /// `marketing_dtor_detour` module doc comment describes - vanilla's own `ZTMARKETING_MGR_1`
+    /// scalar-deleting destructor, if ever allowed to run over a Rust-`Vec`-allocated funding table,
+    /// would call `operator delete` on memory Rust's global allocator owns (the same cross-allocator
+    /// hazard CLAUDE.md's "Live Reimplementation-Comparison Tests" section documents for
+    /// `ZTThoughtMgr`). This deliberately never calls `.original()()` against Rust-allocated memory -
+    /// that would just reproduce the crash the fix exists to prevent.
+    ///
+    /// Two independent halves, like `run_marketingmgr_clear_configurations_test` above:
+    /// - **Real**: a fresh, genuinely vanilla-allocated `ZTMarketingMgr`+`ZTMarketing` (empty funding
+    ///   table, same as that test's real side), torn down via `ZTMARKETING_MGR_1.original()` with
+    ///   `flags=0` (never deletes `this`) - real-allocated, real-freed, so this is safe regardless of the
+    ///   fix and just confirms the real destructor is still callable/well-behaved and returns `this`.
+    /// - **Reimplemented**: a standalone, Rust-`Vec`-allocated non-empty funding table (via
+    ///   `live_support::build_standalone_marketing_with_levels`), torn down via `ZTMarketingMgr::destroy`
+    ///   directly - the actual free path the fix protects.
+    fn run_marketingmgr_dtor_test(failure_log: &mut Option<std::fs::File>) -> bool {
+        let test_name = "ZTMARKETINGMGR_DTOR";
+
+        let real_marketing_raw = unsafe { standalone::OPERATOR_NEW.original()(size_of::<ZTMarketing>() as u32) };
+        if real_marketing_raw.is_null() {
+            error!("{}: OPERATOR_NEW returned null for ZTMarketing, skipping real-side check", test_name);
+        } else {
+            let real_marketing_ptr = unsafe { ztmarketing::CONSTRUCTOR.original()(real_marketing_raw as *const u32) } as *mut ZTMarketing;
+            let real_mgr_ptr = marketing_live_support::build_standalone_marketing_mgr(0, real_marketing_ptr);
+            let real_this = unsafe { ZTMARKETINGMGR_DTOR.original()((real_mgr_ptr as *mut ZTMarketingMgr) as *const u32, 0u8) };
+            if real_this != (real_mgr_ptr as *const u32) {
+                error!("{}: real destructor returned {:?}, expected {:?} (this)", test_name, real_this, real_mgr_ptr);
+                marketing_live_support::destroy_standalone_marketing_mgr(real_mgr_ptr);
+                if let Some(log_file) = failure_log {
+                    let _ = log_file.write_all(format!("Test Failed {}: real destructor did not return `this`\n", test_name).as_bytes());
+                }
+                return true;
+            }
+            // The real destructor already freed `marketing_ptr`'s ZTMarketing (real-allocated, real-freed)
+            // - only the outer Box-allocated ZTMarketingMgr wrapper remains to free here.
+            marketing_live_support::destroy_standalone_marketing_mgr(real_mgr_ptr);
+        }
+
+        let reimpl_marketing_ptr = marketing_live_support::build_standalone_marketing_with_levels(1, &[(100, 5.0), (101, 10.0), (102, 15.0)]);
+        let reimpl_mgr_ptr = marketing_live_support::build_standalone_marketing_mgr(42, reimpl_marketing_ptr);
+        unsafe { &mut *reimpl_mgr_ptr }.destroy();
+        let reimpl_mgr = unsafe { &*reimpl_mgr_ptr };
+        let tick_accumulator_reset = reimpl_mgr.tick_accumulator() == 0;
+        let marketing_ptr_left_dangling = reimpl_mgr.marketing_ptr_raw() != 0;
+        marketing_live_support::destroy_standalone_marketing_mgr(reimpl_mgr_ptr);
+
+        if tick_accumulator_reset && marketing_ptr_left_dangling {
+            info!("{} passed", test_name);
+            write_success_line(failure_log, test_name);
+            false
+        } else {
+            error!(
+                "{} failed: tick_accumulator_reset={}, marketing_ptr_left_dangling={}",
+                test_name, tick_accumulator_reset, marketing_ptr_left_dangling
+            );
+            if let Some(log_file) = failure_log {
+                let _ = log_file.write_all(
+                    format!(
+                        "Test Failed {}: tick_accumulator_reset={}, marketing_ptr_left_dangling={}\n",
+                        test_name, tick_accumulator_reset, marketing_ptr_left_dangling
+                    )
+                    .as_bytes(),
+                );
+            }
+            true
+        }
+    }
+
     /// ZTMARKETINGMGR_LOAD_CONFIGURATIONS: compares the real, live `globals().ztmarketingmgr()`'s
     /// funding table - populated by vanilla's own untouched boot-time `loadConfigurations` call, whose
     /// path was captured into `CAPTURED_MARKETING_PATH` - against this crate's own
@@ -2932,9 +3090,10 @@ mod detour_zoo_main {
                 unsafe { &mut *reimpl_ptr }.add_thought(string_id, 0, 0, 0);
             }
 
-            let real_fields: Vec<_> = unsafe { &*real_ptr }.iter().map(thought_fields).collect();
-            let reimpl_fields: Vec<_> = unsafe { &*reimpl_ptr }.iter().map(thought_fields).collect();
-            let real_len = unsafe { &*real_ptr }.len();
+            let real_thoughts = thought_live_support::read_raw_chain(unsafe { &*real_ptr });
+            let real_fields: Vec<_> = real_thoughts.iter().map(thought_fields).collect();
+            let reimpl_fields: Vec<_> = unsafe { &*reimpl_ptr }.iter().map(|t| thought_fields(&t)).collect();
+            let real_len = real_thoughts.len();
             let reimpl_len = unsafe { &*reimpl_ptr }.len();
 
             thought_live_support::destroy_standalone_mgr_leaking_nodes(real_ptr);
@@ -2960,14 +3119,33 @@ mod detour_zoo_main {
         fail_flag
     }
 
-    /// Seeds `mgr` with one `ZTThought` per `specs` entry (`(string_id, thinker_ptr, object_ptr,
-    /// habitat_ptr)`), front-to-back, via `insert_front` - builds identical starting state for both
-    /// sides of a removal/lookup comparison. `thinker_id`/`object_id`/`tile_x`/`tile_y` are left at
-    /// ctor defaults since no consumer of this helper reads them.
+    /// Seeds `mgr`'s reimplemented-side store with one `ZTThought` per `specs` entry (`(string_id,
+    /// thinker_ptr, object_ptr, habitat_ptr)`), front-to-back, via `insert_front` - for the side of a
+    /// comparison driven through a direct reimplemented-method call. `thinker_id`/`object_id`/`tile_x`/
+    /// `tile_y` are left at ctor defaults since no consumer of this helper reads them.
     fn seed_thoughts(mgr: &mut ZTThoughtMgr, specs: &[(u32, u32, u32, u32)]) {
         for &(string_id, thinker_ptr, object_ptr, habitat_ptr) in specs {
             mgr.insert_front(thought_live_support::new_thought(string_id, 0, 0, -1, -1, thinker_ptr, object_ptr, habitat_ptr));
         }
+    }
+
+    /// Seeds `mgr`'s raw `sentinel_ptr` chain (not its reimplemented-side store) with one `ZTThought` per
+    /// `specs` entry, front-to-back, via `seed_raw_chain` - for the "real" side of a comparison driven
+    /// through a genuine, undetoured `.original()` call, which reads `sentinel_ptr` directly and knows
+    /// nothing about the reimplemented-side store.
+    fn seed_thoughts_raw(mgr: &ZTThoughtMgr, specs: &[(u32, u32, u32, u32)]) {
+        for &(string_id, thinker_ptr, object_ptr, habitat_ptr) in specs {
+            thought_live_support::seed_raw_chain(mgr, thought_live_support::new_thought(string_id, 0, 0, -1, -1, thinker_ptr, object_ptr, habitat_ptr));
+        }
+    }
+
+    /// Seeds `mgr` on *both* representations at once (raw chain and reimplemented-side store) with
+    /// identical content - for tests that drive a *single* instance through both a real `.original()`
+    /// call (reads the raw chain) and a direct reimplemented-method call (reads the store), e.g. the
+    /// `getThoughtsBy*` comparisons below.
+    fn seed_thoughts_both(mgr: &mut ZTThoughtMgr, specs: &[(u32, u32, u32, u32)]) {
+        seed_thoughts_raw(mgr, specs);
+        seed_thoughts(mgr, specs);
     }
 
     fn thought_spec_strategy() -> impl Strategy<Value = (u32, u32, u32, u32)> {
@@ -2991,7 +3169,7 @@ mod detour_zoo_main {
         match runner.run(&(prop::collection::vec(thought_spec_strategy(), 0..8), 0u32..5), |(specs, target)| {
             let real_ptr = thought_live_support::build_standalone_mgr(1000);
             let reimpl_ptr = thought_live_support::build_standalone_mgr(1000);
-            seed_thoughts(unsafe { &mut *real_ptr }, &specs);
+            seed_thoughts_raw(unsafe { &*real_ptr }, &specs);
             seed_thoughts(unsafe { &mut *reimpl_ptr }, &specs);
 
             unsafe {
@@ -2999,10 +3177,10 @@ mod detour_zoo_main {
             }
             unsafe { &mut *reimpl_ptr }.remove_thoughts_by_thinker(target);
 
-            let real_fields: Vec<_> = unsafe { &*real_ptr }.iter().map(thought_fields).collect();
-            let reimpl_fields: Vec<_> = unsafe { &*reimpl_ptr }.iter().map(thought_fields).collect();
+            let real_fields: Vec<_> = thought_live_support::read_raw_chain(unsafe { &*real_ptr }).iter().map(thought_fields).collect();
+            let reimpl_fields: Vec<_> = unsafe { &*reimpl_ptr }.iter().map(|t| thought_fields(&t)).collect();
 
-            thought_live_support::destroy_standalone_mgr(real_ptr);
+            thought_live_support::free_raw_chain_mgr(real_ptr);
             thought_live_support::destroy_standalone_mgr(reimpl_ptr);
 
             prop_assert_eq!(real_fields, reimpl_fields, "mismatch for specs={:?}, target={}", specs, target);
@@ -3039,7 +3217,7 @@ mod detour_zoo_main {
         match runner.run(&(prop::collection::vec(thought_spec_strategy(), 0..8), 0u32..5), |(specs, target)| {
             let real_ptr = thought_live_support::build_standalone_mgr(1000);
             let reimpl_ptr = thought_live_support::build_standalone_mgr(1000);
-            seed_thoughts(unsafe { &mut *real_ptr }, &specs);
+            seed_thoughts_raw(unsafe { &*real_ptr }, &specs);
             seed_thoughts(unsafe { &mut *reimpl_ptr }, &specs);
 
             unsafe {
@@ -3047,10 +3225,10 @@ mod detour_zoo_main {
             }
             unsafe { &mut *reimpl_ptr }.remove_thoughts_by_object(target);
 
-            let real_fields: Vec<_> = unsafe { &*real_ptr }.iter().map(thought_fields).collect();
-            let reimpl_fields: Vec<_> = unsafe { &*reimpl_ptr }.iter().map(thought_fields).collect();
+            let real_fields: Vec<_> = thought_live_support::read_raw_chain(unsafe { &*real_ptr }).iter().map(thought_fields).collect();
+            let reimpl_fields: Vec<_> = unsafe { &*reimpl_ptr }.iter().map(|t| thought_fields(&t)).collect();
 
-            thought_live_support::destroy_standalone_mgr(real_ptr);
+            thought_live_support::free_raw_chain_mgr(real_ptr);
             thought_live_support::destroy_standalone_mgr(reimpl_ptr);
 
             prop_assert_eq!(real_fields, reimpl_fields, "mismatch for specs={:?}, target={}", specs, target);
@@ -3088,7 +3266,7 @@ mod detour_zoo_main {
         match runner.run(&(prop::collection::vec(thought_spec_strategy(), 0..8), 0u32..5, any::<bool>()), |(specs, target, force)| {
             let real_ptr = thought_live_support::build_standalone_mgr(1000);
             let reimpl_ptr = thought_live_support::build_standalone_mgr(1000);
-            seed_thoughts(unsafe { &mut *real_ptr }, &specs);
+            seed_thoughts_raw(unsafe { &*real_ptr }, &specs);
             seed_thoughts(unsafe { &mut *reimpl_ptr }, &specs);
 
             unsafe {
@@ -3096,10 +3274,10 @@ mod detour_zoo_main {
             }
             unsafe { &mut *reimpl_ptr }.remove_thoughts_by_habitat(target, force);
 
-            let real_fields: Vec<_> = unsafe { &*real_ptr }.iter().map(thought_fields).collect();
-            let reimpl_fields: Vec<_> = unsafe { &*reimpl_ptr }.iter().map(thought_fields).collect();
+            let real_fields: Vec<_> = thought_live_support::read_raw_chain(unsafe { &*real_ptr }).iter().map(thought_fields).collect();
+            let reimpl_fields: Vec<_> = unsafe { &*reimpl_ptr }.iter().map(|t| thought_fields(&t)).collect();
 
-            thought_live_support::destroy_standalone_mgr(real_ptr);
+            thought_live_support::free_raw_chain_mgr(real_ptr);
             thought_live_support::destroy_standalone_mgr(reimpl_ptr);
 
             prop_assert_eq!(real_fields, reimpl_fields, "mismatch for specs={:?}, target={}, force={}", specs, target, force);
@@ -3123,9 +3301,11 @@ mod detour_zoo_main {
 
     /// ZTTHOUGHTMGR_GET_THOUGHTS_BY_THINKER: compares the real, undetoured `getThoughtsByThinker`'s
     /// output - a real vanilla temporary list, walked read-only via
-    /// `thought_live_support::read_only_wrap_vanilla_list` - against the reimplemented
-    /// `get_thoughts_by_thinker`, on a single seeded standalone manager (both calls only read the
-    /// manager's own list, so there's no need for two independent instances).
+    /// `thought_live_support::read_raw_chain_from_sentinel` - against the reimplemented
+    /// `get_thoughts_by_thinker`, on a single standalone manager seeded on both representations via
+    /// `seed_thoughts_both` (the real call reads its raw `sentinel_ptr` chain; the reimplemented call
+    /// reads its `THOUGHT_STORES` entry - a single instance can drive both since they're independent
+    /// storage, no need for two separate instances).
     fn run_thoughtmgr_get_thoughts_by_thinker_test(failure_log: &mut Option<std::fs::File>) -> bool {
         let runner_config = ProptestConfig {
             failure_persistence: Some(Box::new(super::NoopFailurePersistence)),
@@ -3137,7 +3317,7 @@ mod detour_zoo_main {
 
         match runner.run(&(prop::collection::vec(thought_spec_strategy(), 0..8), 0u32..5, 1i32..5), |(specs, target, max_count)| {
             let mgr_ptr = thought_live_support::build_standalone_mgr(1000);
-            seed_thoughts(unsafe { &mut *mgr_ptr }, &specs);
+            seed_thoughts_both(unsafe { &mut *mgr_ptr }, &specs);
             let mgr = unsafe { &*mgr_ptr };
 
             let mut real_sentinel: u32 = 0;
@@ -3149,12 +3329,12 @@ mod detour_zoo_main {
                     max_count,
                 );
             }
-            let real_wrapper = thought_live_support::read_only_wrap_vanilla_list(real_sentinel);
-            let real_fields: Vec<_> = real_wrapper.iter().map(thought_fields).collect();
+            let real_fields: Vec<_> = thought_live_support::read_raw_chain_from_sentinel(real_sentinel).iter().map(thought_fields).collect();
 
-            let reimpl_fields: Vec<_> = mgr.get_thoughts_by_thinker(target, max_count as usize).into_iter().map(|t| thought_fields(t)).collect();
+            let reimpl_thoughts = mgr.get_thoughts_by_thinker(target, max_count as usize);
+            let reimpl_fields: Vec<_> = reimpl_thoughts.iter().map(thought_fields).collect();
 
-            thought_live_support::destroy_standalone_mgr(mgr_ptr);
+            thought_live_support::destroy_standalone_mgr_both(mgr_ptr);
 
             prop_assert_eq!(real_fields, reimpl_fields, "mismatch for specs={:?}, target={}, max_count={}", specs, target, max_count);
             Ok(())
@@ -3191,7 +3371,7 @@ mod detour_zoo_main {
 
         match runner.run(&(prop::collection::vec(thought_spec_strategy(), 0..8), 0u32..5, 1i32..5), |(specs, target, max_count)| {
             let mgr_ptr = thought_live_support::build_standalone_mgr(1000);
-            seed_thoughts(unsafe { &mut *mgr_ptr }, &specs);
+            seed_thoughts_both(unsafe { &mut *mgr_ptr }, &specs);
             let mgr = unsafe { &*mgr_ptr };
 
             let mut real_sentinel: u32 = 0;
@@ -3203,12 +3383,12 @@ mod detour_zoo_main {
                     max_count as *const i32,
                 );
             }
-            let real_wrapper = thought_live_support::read_only_wrap_vanilla_list(real_sentinel);
-            let real_fields: Vec<_> = real_wrapper.iter().map(thought_fields).collect();
+            let real_fields: Vec<_> = thought_live_support::read_raw_chain_from_sentinel(real_sentinel).iter().map(thought_fields).collect();
 
-            let reimpl_fields: Vec<_> = mgr.get_thoughts_by_object(target, max_count as usize).into_iter().map(|t| thought_fields(t)).collect();
+            let reimpl_thoughts = mgr.get_thoughts_by_object(target, max_count as usize);
+            let reimpl_fields: Vec<_> = reimpl_thoughts.iter().map(thought_fields).collect();
 
-            thought_live_support::destroy_standalone_mgr(mgr_ptr);
+            thought_live_support::destroy_standalone_mgr_both(mgr_ptr);
 
             prop_assert_eq!(real_fields, reimpl_fields, "mismatch for specs={:?}, target={}, max_count={}", specs, target, max_count);
             Ok(())
@@ -3243,7 +3423,7 @@ mod detour_zoo_main {
 
         match runner.run(&(prop::collection::vec(thought_spec_strategy(), 0..8), 0u32..5, 1i32..20), |(specs, target, max_count)| {
             let mgr_ptr = thought_live_support::build_standalone_mgr(1000);
-            seed_thoughts(unsafe { &mut *mgr_ptr }, &specs);
+            seed_thoughts_both(unsafe { &mut *mgr_ptr }, &specs);
             let mgr = unsafe { &*mgr_ptr };
 
             let mut real_sentinel: u32 = 0;
@@ -3255,12 +3435,12 @@ mod detour_zoo_main {
                     max_count as *const i32,
                 );
             }
-            let real_wrapper = thought_live_support::read_only_wrap_vanilla_list(real_sentinel);
-            let real_fields: Vec<_> = real_wrapper.iter().map(thought_fields).collect();
+            let real_fields: Vec<_> = thought_live_support::read_raw_chain_from_sentinel(real_sentinel).iter().map(thought_fields).collect();
 
-            let reimpl_fields: Vec<_> = mgr.get_thoughts_by_habitat(target, max_count as usize).into_iter().map(|t| thought_fields(t)).collect();
+            let reimpl_thoughts = mgr.get_thoughts_by_habitat(target, max_count as usize);
+            let reimpl_fields: Vec<_> = reimpl_thoughts.iter().map(thought_fields).collect();
 
-            thought_live_support::destroy_standalone_mgr(mgr_ptr);
+            thought_live_support::destroy_standalone_mgr_both(mgr_ptr);
 
             prop_assert_eq!(real_fields, reimpl_fields, "mismatch for specs={:?}, target={}, max_count={}", specs, target, max_count);
             Ok(())
@@ -3297,7 +3477,10 @@ mod detour_zoo_main {
             let real_ptr = thought_live_support::build_standalone_mgr(1000);
             let reimpl_ptr = thought_live_support::build_standalone_mgr(1000);
             for &(string_id, thinker_id, object_id, tile_x, tile_y) in &records {
-                unsafe { &mut *real_ptr }.insert_front(thought_live_support::new_thought(string_id, thinker_id, object_id, tile_x, tile_y, 0, 0, 0));
+                thought_live_support::seed_raw_chain(
+                    unsafe { &*real_ptr },
+                    thought_live_support::new_thought(string_id, thinker_id, object_id, tile_x, tile_y, 0, 0, 0),
+                );
                 unsafe { &mut *reimpl_ptr }.insert_front(thought_live_support::new_thought(string_id, thinker_id, object_id, tile_x, tile_y, 0, 0, 0));
             }
 
@@ -3310,7 +3493,7 @@ mod detour_zoo_main {
             let _ = unsafe { &*reimpl_ptr }.save(&dummy_file as *const u32);
             let reimpl_bytes = io_redirect::end_capture();
 
-            thought_live_support::destroy_standalone_mgr(real_ptr);
+            thought_live_support::free_raw_chain_mgr(real_ptr);
             thought_live_support::destroy_standalone_mgr(reimpl_ptr);
 
             prop_assert_eq!(real_bytes, reimpl_bytes, "save byte mismatch for records={:?}", records);
@@ -3372,8 +3555,8 @@ mod detour_zoo_main {
             let reimpl_ret = unsafe { &mut *reimpl_ptr }.load(file_buffer.as_ptr(), version);
             io_redirect::end_replay();
 
-            let real_fields: Vec<_> = unsafe { &*real_ptr }.iter().map(thought_fields).collect();
-            let reimpl_fields: Vec<_> = unsafe { &*reimpl_ptr }.iter().map(thought_fields).collect();
+            let real_fields: Vec<_> = thought_live_support::read_raw_chain(unsafe { &*real_ptr }).iter().map(thought_fields).collect();
+            let reimpl_fields: Vec<_> = unsafe { &*reimpl_ptr }.iter().map(|t| thought_fields(&t)).collect();
 
             thought_live_support::destroy_standalone_mgr_leaking_nodes(real_ptr);
             thought_live_support::destroy_standalone_mgr(reimpl_ptr);
@@ -3396,6 +3579,279 @@ mod detour_zoo_main {
         }
 
         fail_flag
+    }
+
+    // ============================================================================================
+    // ZTAwardMgr - see openzt/src/ztawardmgr.rs and openzt/plans/ztawardmgr-implementation-plan.md.
+    // `_ADD_AWARD_SAVE_LOAD`/`_START`/`_GET_AWARD` and `ZTSCENARIOSIMPLEGOAL_EVAL_AWARD_COUNT` are
+    // self-contained (resources are already loaded by this early injection point, and none of them
+    // need `GLOBAL_ZTWorldMgr`), so they run from the early battery above. `_SHOW_AWARDS` needs a live
+    // `BFUIMgr` element, so it runs from `run_on_completion_reset_test_and_exit`'s later chain instead,
+    // after `run_load_live_zoo`.
+    // ============================================================================================
+
+    /// Resets both the real vanilla singleton's earned-id vector and the Rust-side store to empty.
+    /// Exploits `ZTAwardMgr::load`'s own "reset-then-fill" semantics as a safe, allocator-agnostic clear
+    /// for the real side (feeding a single `0i32` count via `io_redirect::begin_replay` means the real
+    /// `load` resets the vector, reads a `0` count, and returns immediately without calling `addAward`)
+    /// - there's no dedicated clear method and no way to build a second standalone instance for this
+    /// class (see `ztawardmgr.rs`'s module doc comment).
+    fn reset_awardmgr_both_sides() {
+        let real_ptr = award_live_support::real_ptr();
+        let file_buffer = [0u32; 4];
+        io_redirect::begin_replay(0u32.to_le_bytes().to_vec());
+        unsafe { gen_ztawardmgr::LOAD.original()(real_ptr, file_buffer.as_ptr(), 0) };
+        io_redirect::end_replay();
+        award_live_support::reset_reimplemented_store();
+    }
+
+    /// ZTAWARDMGR_ADD_AWARD_SAVE_LOAD: for a generated sequence of ids, feeds the same sequence through
+    /// the real `ADD_AWARD.original()` and the reimplemented `ztawardmgr::add_award` independently (both
+    /// sides reset to empty first via `reset_awardmgr_both_sides`), then compares the real
+    /// `SAVE.original()`'s captured output (via `io_redirect`) against the reimplemented `save`'s own
+    /// output - should be byte-identical, since both reproduce the exact `i32` count + `i32[count]` wire
+    /// format.
+    fn run_awardmgr_add_award_save_load_test(failure_log: &mut Option<std::fs::File>) -> bool {
+        let runner_config = ProptestConfig {
+            failure_persistence: Some(Box::new(super::NoopFailurePersistence)),
+            ..ProptestConfig::default()
+        };
+        let mut runner = proptest::test_runner::TestRunner::new(runner_config);
+        let test_name = "ZTAWARDMGR_ADD_AWARD_SAVE_LOAD";
+        let mut fail_flag = false;
+
+        match runner.run(&prop::collection::vec(any::<i32>(), 0..8), |ids| {
+            let real_ptr = award_live_support::real_ptr();
+            reset_awardmgr_both_sides();
+
+            for &id in &ids {
+                unsafe { gen_ztawardmgr::ADD_AWARD.original()(real_ptr, id) };
+                ztawardmgr::add_award(id);
+            }
+
+            let dummy_file: u32 = 0;
+            io_redirect::begin_capture();
+            unsafe { gen_ztawardmgr::SAVE.original()(real_ptr, &dummy_file as *const u32 as *const i8) };
+            let real_bytes = io_redirect::end_capture();
+
+            io_redirect::begin_capture();
+            let _ = ztawardmgr::save(&dummy_file as *const u32);
+            let reimpl_bytes = io_redirect::end_capture();
+
+            prop_assert_eq!(real_bytes, reimpl_bytes, "save byte mismatch for ids={:?}", ids);
+            Ok(())
+        }) {
+            Ok(_) => {
+                info!("Proptest passed for {}", test_name);
+                write_success_line(failure_log, test_name);
+            }
+            Err(e) => {
+                error!("Proptest failed: {:?}", e);
+                if let Some(log_file) = failure_log {
+                    let _ = log_file.write_all(format!("Test Failed {}: {:?}\n", test_name, e).as_bytes());
+                }
+                fail_flag = true;
+            }
+        }
+
+        fail_flag
+    }
+
+    /// ZTAWARDMGR_START: calls the real `START.original()` against the live singleton (whose tree is
+    /// still empty at this early injection point) to populate it from the real live `award.cfg`
+    /// resource, then calls the reimplemented `ztawardmgr::start()` against the same resource data.
+    /// Compares every `(id, name_id, tooltip_id)` triple - `award_live_support::read_vanilla_award_tree`
+    /// reads the real tree via a read-only in-order walk (never mutates/frees anything, so safe
+    /// regardless of which allocator built the nodes), `award_live_support::reimplemented_award_triples`
+    /// reads the Rust-side `BTreeMap` (already sorted by id, matching the in-order walk's order). Not a
+    /// proptest - there's exactly one real `award.cfg`/one real answer to compare, matching
+    /// `ZTMARKETINGMGR_LOAD_CONFIGURATIONS`'s precedent.
+    fn run_awardmgr_start_test(failure_log: &mut Option<std::fs::File>) -> bool {
+        let test_name = "ZTAWARDMGR_START";
+        let real_ptr = award_live_support::real_ptr();
+
+        let real_ok = (unsafe { gen_ztawardmgr::START.original()(real_ptr) } & 0xff) != 0;
+        let real_tree = award_live_support::read_vanilla_award_tree();
+
+        let reimpl_ok = ztawardmgr::start();
+        let reimpl_tree = award_live_support::reimplemented_award_triples();
+
+        if real_ok == reimpl_ok && real_tree == reimpl_tree {
+            info!("{} passed ({} awards)", test_name, real_tree.len());
+            write_success_line(failure_log, test_name);
+            false
+        } else {
+            error!(
+                "{} failed: real_ok={}, reimpl_ok={}, real_tree={:?}, reimpl_tree={:?}",
+                test_name, real_ok, reimpl_ok, real_tree, reimpl_tree
+            );
+            if let Some(log_file) = failure_log {
+                let _ = log_file.write_all(
+                    format!(
+                        "Test Failed {}: real_ok={}, reimpl_ok={}, real_tree={:?}, reimpl_tree={:?}\n",
+                        test_name, real_ok, reimpl_ok, real_tree, reimpl_tree
+                    )
+                    .as_bytes(),
+                );
+            }
+            true
+        }
+    }
+
+    /// ZTAWARDMGR_GET_AWARD: for every id `ZTAWARDMGR_START` found in the real tree (plus one
+    /// guaranteed-absent id), compares the real `GET_AWARD.original()`'s dereferenced `+0x14`/`+0x18`
+    /// fields (or "not found", when the raw returned pointer is `0`) against the reimplemented
+    /// `ztawardmgr::get_award`. Must run after `run_awardmgr_start_test` - relies on both trees already
+    /// being populated identically.
+    fn run_awardmgr_get_award_test(failure_log: &mut Option<std::fs::File>) -> bool {
+        let test_name = "ZTAWARDMGR_GET_AWARD";
+        let real_ptr = award_live_support::real_ptr();
+        let real_tree = award_live_support::read_vanilla_award_tree();
+
+        let mut ids: Vec<i32> = real_tree.iter().map(|&(id, _, _)| id).collect();
+        let absent_id = ids.iter().copied().max().unwrap_or(0).wrapping_add(1_000_000);
+        ids.push(absent_id);
+
+        let mut fail_flag = false;
+        for id in ids {
+            let real_result_ptr = unsafe { gen_ztawardmgr::GET_AWARD.original()(real_ptr, id) };
+            let real = if real_result_ptr == 0 {
+                None
+            } else {
+                Some((get_from_memory::<i32>(real_result_ptr as u32), get_from_memory::<i32>(real_result_ptr as u32 + 4)))
+            };
+
+            let reimpl = ztawardmgr::get_award(id).map(|a| (a.name_id(), a.tooltip_id()));
+
+            if real != reimpl {
+                error!("{} mismatch for id={}: real={:?}, reimpl={:?}", test_name, id, real, reimpl);
+                if let Some(log_file) = failure_log {
+                    let _ =
+                        log_file.write_all(format!("Test Failed {}: id={}, real={:?}, reimpl={:?}\n", test_name, id, real, reimpl).as_bytes());
+                }
+                fail_flag = true;
+            }
+        }
+
+        if !fail_flag {
+            write_success_line(failure_log, test_name);
+        }
+        fail_flag
+    }
+
+    /// ZTSCENARIOSIMPLEGOAL_EVAL_AWARD_COUNT: drives `ZTScenarioSimpleGoal::eval`'s installed override
+    /// by calling through its real, now-patched address directly (`ztawardmgr::init` has already
+    /// installed the detour by this point in the battery, and the game's `.exe` has no ASLR, so the raw
+    /// Ghidra VA is safe to call via a plain `transmute` - same pattern `ztthoughtmgr.rs`'s
+    /// `resolve_object_own_habitat_ptr` uses for a vtable slot). Builds a fully synthetic, zeroed,
+    /// leaked buffer standing in for a `ZTScenarioSimpleGoal*` (safe: every case exercised here only
+    /// touches `+0xc`/`+0x10`/`+0x1c` on `this`), seeds a known, identical, non-zero award count on both
+    /// representations (the real vector via `ADD_AWARD.original()`, the Rust store via
+    /// `ztawardmgr::add_award`) so a mismatch would be visible, then compares the real, un-hooked
+    /// `EVAL.original()` against a direct call through the hooked address for: the gate-passing case at
+    /// the exact threshold boundary (both should equal the seeded count, since both representations are
+    /// in sync), the gate-failing case just past the boundary, and two unrelated submetric values under
+    /// the same goal kind - the override must fall through to identical vanilla behavior for all three of
+    /// those.
+    fn run_ztscenariosimplegoal_eval_award_count_test(failure_log: &mut Option<std::fs::File>) -> bool {
+        let test_name = "ZTSCENARIOSIMPLEGOAL_EVAL_AWARD_COUNT";
+        let game_mgr_ptr = globals().ztgamemgr_ptr();
+        if game_mgr_ptr.is_null() {
+            info!("Skipping {}: GLOBAL_ZTGameMgr not initialized at this injection point", test_name);
+            write_success_line(failure_log, &format!("{} (skipped: ZTGameMgr not initialized)", test_name));
+            return false;
+        }
+
+        let field_0x15c = get_from_memory::<i32>(game_mgr_ptr as u32 + 0x15c);
+        let field_0x160 = get_from_memory::<i32>(game_mgr_ptr as u32 + 0x160);
+        let threshold_boundary = field_0x15c + field_0x160 * 12;
+
+        let real_ptr = award_live_support::real_ptr();
+        reset_awardmgr_both_sides();
+        for id in [9_100_001i32, 9_100_002, 9_100_003] {
+            unsafe { gen_ztawardmgr::ADD_AWARD.original()(real_ptr, id) };
+            ztawardmgr::add_award(id);
+        }
+
+        let goal_buf = Box::into_raw(Box::new([0u8; 0x20]));
+        let goal_ptr = goal_buf as *const u32;
+
+        let cases: [(&str, i32, i32, i32); 4] = [
+            ("gate-passing at boundary", 1, 0xb, threshold_boundary),
+            ("gate-failing just past boundary", 1, 0xb, threshold_boundary + 1),
+            ("unrelated submetric 0", 1, 0, threshold_boundary),
+            ("unrelated submetric 7", 1, 7, threshold_boundary),
+        ];
+
+        let mut fail_flag = false;
+        for (label, kind, submetric, threshold) in cases {
+            save_to_memory::<i32>(goal_ptr as u32 + 0xc, kind);
+            save_to_memory::<i32>(goal_ptr as u32 + 0x10, submetric);
+            save_to_memory::<i32>(goal_ptr as u32 + 0x1c, threshold);
+
+            let expected = unsafe { ZTSCENARIOSIMPLEGOAL_EVAL.original()(goal_ptr) };
+            let hooked = unsafe { std::mem::transmute::<u32, extern "thiscall" fn(*const u32) -> i32>(0x0041d665u32) };
+            let actual = hooked(goal_ptr);
+
+            if expected != actual {
+                error!("{} mismatch for case '{}': expected={}, actual={}", test_name, label, expected, actual);
+                if let Some(log_file) = failure_log {
+                    let _ = log_file
+                        .write_all(format!("Test Failed {}: case '{}', expected={}, actual={}\n", test_name, label, expected, actual).as_bytes());
+                }
+                fail_flag = true;
+            }
+        }
+
+        drop(unsafe { Box::from_raw(goal_buf) });
+
+        if !fail_flag {
+            write_success_line(failure_log, test_name);
+        }
+        fail_flag
+    }
+
+    /// ZTAWARDMGR_SHOW_AWARDS: smoke-tests the reimplemented `_showAwards` (installed as a
+    /// full-replacement detour, not a partial override) by calling through its real, now-patched address
+    /// after seeding both representations with the same real catalogue award ids (from
+    /// `ZTAWARDMGR_START`, which has already run earlier in this battery). Runs after `run_load_live_zoo`
+    /// since it needs a live `BFUIMgr` element `0x101c` to exist. Confirms the call resolves the list
+    /// element and completes without crashing; per `ztawardmgr.rs`'s `show_awards_detour` doc comment,
+    /// the icon-buffer/color-argument shape and the `load_string_by_id`-vs-`buildString` text
+    /// equivalence are flagged as open items needing separate manual live verification, not structural
+    /// comparison here.
+    fn run_awardmgr_show_awards_test(failure_log: &mut Option<std::fs::File>) -> bool {
+        let test_name = "ZTAWARDMGR_SHOW_AWARDS";
+
+        let global_bfuimgr = (get_module_base("zoo.exe") as u32 + 0x0023_8de0) as *const u32;
+        let element = unsafe { BFUIMGR_GET_ELEMENT_0.original()(global_bfuimgr, 0x101c) };
+        if element.is_null() {
+            info!("Skipping {}: BFUIMgr element 0x101c not resolved", test_name);
+            write_success_line(failure_log, &format!("{} (skipped: element not resolved)", test_name));
+            return false;
+        }
+
+        let catalogue = award_live_support::reimplemented_award_triples();
+        if catalogue.is_empty() {
+            info!("Skipping {}: no award catalogue entries available (ZTAWARDMGR_START found none)", test_name);
+            write_success_line(failure_log, &format!("{} (skipped: empty catalogue)", test_name));
+            return false;
+        }
+
+        let real_ptr = award_live_support::real_ptr();
+        reset_awardmgr_both_sides();
+        let exercised_count = catalogue.len().min(2);
+        for &(id, _, _) in catalogue.iter().take(2) {
+            unsafe { gen_ztawardmgr::ADD_AWARD.original()(real_ptr, id) };
+            ztawardmgr::add_award(id);
+        }
+
+        let hooked = unsafe { std::mem::transmute::<u32, extern "stdcall" fn()>(0x0053167fu32) };
+        hooked();
+
+        info!("{} completed without crashing (exercised {} award ids)", test_name, exercised_count);
+        write_success_line(failure_log, test_name);
+        false
     }
 
     /// ZTTHOUGHTMGR_LOAD_MODERN: compares the real `ZTThoughtMgr::load`'s effect against the
@@ -3459,8 +3915,8 @@ mod detour_zoo_main {
             let reimpl_ret = unsafe { &mut *reimpl_ptr }.load(file_buffer.as_ptr(), version);
             io_redirect::end_replay();
 
-            let real_fields: Vec<_> = unsafe { &*real_ptr }.iter().map(thought_fields).collect();
-            let reimpl_fields: Vec<_> = unsafe { &*reimpl_ptr }.iter().map(thought_fields).collect();
+            let real_fields: Vec<_> = thought_live_support::read_raw_chain(unsafe { &*real_ptr }).iter().map(thought_fields).collect();
+            let reimpl_fields: Vec<_> = unsafe { &*reimpl_ptr }.iter().map(|t| thought_fields(&t)).collect();
 
             thought_live_support::destroy_standalone_mgr_leaking_nodes(real_ptr);
             thought_live_support::destroy_standalone_mgr(reimpl_ptr);
@@ -3551,8 +4007,8 @@ mod detour_zoo_main {
             }
             unsafe { &mut *reimpl_ptr }.add_thought(string_id, 0, animal_addr, fallback_habitat_ptr);
 
-            let real_fields: Vec<_> = unsafe { &*real_ptr }.iter().map(thought_fields).collect();
-            let reimpl_fields: Vec<_> = unsafe { &*reimpl_ptr }.iter().map(thought_fields).collect();
+            let real_fields: Vec<_> = thought_live_support::read_raw_chain(unsafe { &*real_ptr }).iter().map(thought_fields).collect();
+            let reimpl_fields: Vec<_> = unsafe { &*reimpl_ptr }.iter().map(|t| thought_fields(&t)).collect();
 
             thought_live_support::destroy_standalone_mgr_leaking_nodes(real_ptr);
             thought_live_support::destroy_standalone_mgr(reimpl_ptr);
@@ -3605,17 +4061,20 @@ mod detour_zoo_main {
             let real_ptr = thought_live_support::build_standalone_mgr(1000);
             let reimpl_ptr = thought_live_support::build_standalone_mgr(1000);
             for &(string_id, thinker_id, object_id) in &records {
-                unsafe { &mut *real_ptr }.insert_front(thought_live_support::new_thought(string_id, thinker_id, object_id, -1, -1, 0, 0, 0));
+                thought_live_support::seed_raw_chain(
+                    unsafe { &*real_ptr },
+                    thought_live_support::new_thought(string_id, thinker_id, object_id, -1, -1, 0, 0, 0),
+                );
                 unsafe { &mut *reimpl_ptr }.insert_front(thought_live_support::new_thought(string_id, thinker_id, object_id, -1, -1, 0, 0, 0));
             }
 
             unsafe { gen_ztthoughtmgr::POPULATE_THOUGHTS.original()(real_ptr as *const u32) };
             unsafe { &mut *reimpl_ptr }.populate_thoughts();
 
-            let real_fields: Vec<_> = unsafe { &*real_ptr }.iter().map(thought_fields).collect();
-            let reimpl_fields: Vec<_> = unsafe { &*reimpl_ptr }.iter().map(thought_fields).collect();
+            let real_fields: Vec<_> = thought_live_support::read_raw_chain(unsafe { &*real_ptr }).iter().map(thought_fields).collect();
+            let reimpl_fields: Vec<_> = unsafe { &*reimpl_ptr }.iter().map(|t| thought_fields(&t)).collect();
 
-            thought_live_support::destroy_standalone_mgr(real_ptr);
+            thought_live_support::free_raw_chain_mgr(real_ptr);
             thought_live_support::destroy_standalone_mgr(reimpl_ptr);
 
             prop_assert_eq!(real_fields, reimpl_fields, "mismatch for records={:?}", records);
@@ -3684,6 +4143,21 @@ mod detour_zoo_main {
         ]
     }
 
+    /// True if `template` is shaped the way every real, decompile-confirmed `ZTThought` message is: either
+    /// no `%` conversion at all, or exactly one `%s`. Real vanilla always calls `wsprintfA(dest, template,
+    /// name_ptr)` with exactly one argument when a substitution is attempted (see
+    /// `ztthought-getstring-pluralization-bug-handover.md`); this reimplementation's naive
+    /// `replacen("%s", name, 1)` only agrees with that for templates shaped this way - confirmed against
+    /// every real thought-message string id `ZTGuest::fGuestThought`'s call sites use (see
+    /// `run_thought_get_string_test`'s own doc comment).
+    fn is_single_percent_s_or_none(template: &str) -> bool {
+        match template.matches('%').count() {
+            0 => true,
+            1 => template.contains("%s"),
+            _ => false,
+        }
+    }
+
     /// ZTTHOUGHT_GET_STRING: compares the real `ZTThought::getString`'s output against the reimplemented
     /// `get_string`, across all three substitution branches: no substitution (`object_ptr = habitat_ptr
     /// = 0`), object-name substitution (a fixture `BFEntity` with its `name` field set via
@@ -3694,7 +4168,34 @@ mod detour_zoo_main {
     /// `run_on_completion_reset_test_and_exit`'s later chain: language DLLs, which
     /// `load_string_by_id`/`BFApp::loadString` both depend on, aren't loaded yet at the early injection
     /// point.
+    ///
+    /// `string_id` is fuzzed unconstrained across `any::<u32>()`, which can land on a real, loadable
+    /// string that has nothing to do with `ZTThought` (e.g. a research-progress `"Months to complete:
+    /// %d"` or a marketing `"Adopt %d %r(s)."` string). Real vanilla's `getString` always calls
+    /// `wsprintfA` with exactly one variadic argument no matter what the template asks for, so it only
+    /// agrees with this reimplementation's `replacen("%s", name, 1)` when the template has zero `%`
+    /// conversions or exactly one `%s`. Every real `ZTThought` message is proven to be shaped that way:
+    /// the closed set of literal string-id constants baked into `zoo.exe` at `ZTGuest::fGuestThought`'s
+    /// call sites (`0x2758, 0x2759, 0x27fe, 0x2803, 0x2806, 0x2807, 0x280a, 0x282d, 0x2946, 0x2948,
+    /// 0x2972, 0x2974, 0x2975`) resolve, per the official string-table dumps, to templates that are
+    /// either plain text or exactly one `%s` - never `%d`, never a repeated `%s`. Below, resolved
+    /// templates outside that shape are discarded via `prop_assume!` rather than filtering `string_id`
+    /// itself, so the fuzzer/shrinker still exercises the full `u32` space and every id that does resolve
+    /// to a real `%s`-or-none template. This filtering is skipped for `GetStringSubstitution::None`:
+    /// when both `object_ptr` and `habitat_ptr` are null, real vanilla skips `wsprintfA` entirely and
+    /// returns the template untouched, and the reimplementation does the same, so both sides already
+    /// agree unconditionally there for any template shape.
+    ///
+    /// Known accepted limitation: a few `fGuestThought` call sites (`ZTBuilding_addUser.c`'s `iVar10`,
+    /// `ZTGuest_consumeItem.c`'s `param_1[8]`, `ZTGuest_listen{,_maybe}.c`'s `uVar7`/`uVar4`) pass a
+    /// runtime-computed string id rather than a literal, so they aren't covered by the enumeration above.
+    /// `param_1[8]` in particular looks `.cfg`-driven, so a mod with a custom item config could in
+    /// principle point it at a non-`%s`-shaped string and hit a real (if narrow, mod-specific) divergence
+    /// this fix doesn't address.
     fn run_thought_get_string_test(failure_log: &mut Option<std::fs::File>) -> bool {
+        debug_assert!(!is_single_percent_s_or_none("Adopt %d %r(s)."));
+        debug_assert!(!is_single_percent_s_or_none("Months to complete: %d"));
+
         let runner_config = ProptestConfig {
             failure_persistence: Some(Box::new(super::NoopFailurePersistence)),
             ..ProptestConfig::default()
@@ -3704,6 +4205,12 @@ mod detour_zoo_main {
         let mut fail_flag = false;
 
         match runner.run(&(any::<u32>(), get_string_substitution_strategy()), |(string_id, case)| {
+            if !matches!(case, GetStringSubstitution::None)
+                && let Some(template) = &crate::string_registry::load_string_by_id(string_id)
+            {
+                prop_assume!(is_single_percent_s_or_none(template));
+            }
+
             let entity_storage = BFEntity::new_for_test(0, 0, 0);
             let habitat_storage: ZTHabitat = unsafe { std::mem::zeroed() };
             let _name_buf: Option<Vec<u8>>;

--- a/openzt/src/ztawardmgr.rs
+++ b/openzt/src/ztawardmgr.rs
@@ -1,0 +1,549 @@
+//! Structs and methods for the vanilla `ZTAwardMgr` class, which tracks which zoo-achievement awards the
+//! player has earned (persisted) and the catalogue of awards the `award*.cfg` resource files define (rebuilt from resources
+//! every load, never persisted).
+//!
+//! Unlike this codebase's other `ZT*Mgr` reimplementations (`ZTMarketingMgr`/`ZTResearchMgr`/
+//! `ZTThoughtMgr`/`ZTMegatileMgr`), `ZTAwardMgr` has no vtable and its global instance is a
+//! **directly-embedded** struct at a fixed address (`0x006390e8`), not a pointer to a heap allocation - see
+//! `private/docs/vtables/ZTAwardMgr.md`. A full decompile-corpus grep found exactly two external callers
+//! that read its fields directly (bypassing any method call): `ZTScenarioSimpleGoal::eval`'s case `0xb`
+//! arm (see [`eval_award_count_override`]) and `_showAwards` (see [`show_awards_detour`]) - both of those
+//! are reimplemented/detoured here too, closing the surface. Every other caller goes through a plain
+//! method call and is layout-agnostic.
+//!
+//! That closed surface makes this class a candidate for CLAUDE.md's "fully independent Rust store" style:
+//! the constructor/destructor are deliberately left un-detoured (vanilla's own copy of the tree/vector
+//! becomes inert dead weight, never read or written by any of the code below), which sidesteps the
+//! cross-allocator hazard class entirely. [`live_support::read_vanilla_award_tree`] is the sole exception -
+//! a read-only, never-mutating/freeing walk of vanilla's real tree, used only by the live-comparison test
+//! suite to check the two representations agree.
+
+use std::{
+    collections::BTreeMap,
+    sync::{LazyLock, Mutex},
+};
+
+use openzt_configparser::ini::Ini;
+use openzt_detour::generated::standalone::{DEALLOCATE, WRITE_BYTES_TO_FILE};
+use tracing::error;
+
+use crate::{
+    encoding_utils::decode_game_text,
+    globals::{get_module_base, globals},
+    resource_manager::lazyresourcemap::get_file,
+    string_registry::load_string_by_id,
+    util::{get_from_memory, ZTBufferString},
+};
+
+/// One entry in the `award*.cfg` catalogue - rebuilt from resources by [`start`] every load, never
+/// persisted.
+#[derive(Debug, Clone, Default)]
+pub struct AwardData {
+    name_id: i32,
+    tooltip_id: i32,
+    icon: String,
+}
+
+impl AwardData {
+    pub fn name_id(&self) -> i32 {
+        self.name_id
+    }
+
+    pub fn tooltip_id(&self) -> i32 {
+        self.tooltip_id
+    }
+
+    pub fn icon(&self) -> &str {
+        &self.icon
+    }
+}
+
+/// Process-global store backing the one real `ZTAwardMgr` singleton. Unlike `ztthoughtmgr.rs`'s
+/// `HashMap<u32, ..>`-keyed registry, there's only ever one real instance and its address is a
+/// compile-time constant baked into vanilla's own constructor (never passed as a parameter anywhere), so
+/// no per-instance key is needed here.
+#[derive(Debug, Default)]
+struct ZTAwardMgrState {
+    /// Vanilla's `+0xc` `vector<int>` - the earned/awarded award-id set, kept sorted and deduped.
+    /// Persisted by [`save`]/[`load`].
+    earned_ids: Vec<i32>,
+    /// Vanilla's `+0x0` red-black tree - the `award*.cfg` catalogue, keyed by award id. Rebuilt by
+    /// [`start`] every load; never persisted.
+    awards: BTreeMap<i32, AwardData>,
+}
+
+static AWARD_MGR: LazyLock<Mutex<ZTAwardMgrState>> = LazyLock::new(|| Mutex::new(ZTAwardMgrState::default()));
+
+/// Reimplementation of `OOAnalyzer::ZTAwardMgr::addAward`. Vanilla's duplicate check is a genuine linear
+/// scan (`for (piVar7 = begin; piVar7 != end && *piVar7 != param_1; ...)`), independent of any
+/// ordering. The insertion-sort-shaped code that follows a successful append (confirmed live via
+/// `ZTAWARDMGR_ADD_AWARD_SAVE_LOAD` - `add_award([0, -1])` produces `[0, -1]`, not the ascending `[-1,
+/// 0]` an initial ascending-binary-search implementation of this function produced) keeps the vector
+/// sorted **descending** (largest first), not ascending - confirmed by hand-tracing
+/// `ZTAwardMgr_addAward.c`'s inner comparisons (`*piVar4 < iVar11` / `iVar8 < iVar11`), which shift
+/// smaller existing elements rightward to make room for a larger new one at the front.
+fn insert_sorted_unique(ids: &mut Vec<i32>, id: i32) {
+    if ids.contains(&id) {
+        return;
+    }
+    let pos = ids.partition_point(|&x| x > id);
+    ids.insert(pos, id);
+}
+
+pub fn add_award(id: i32) {
+    let mut state = AWARD_MGR.lock().unwrap();
+    insert_sorted_unique(&mut state.earned_ids, id);
+}
+
+/// Reimplementation of `OOAnalyzer::ZTAwardMgr::getAward`'s tree lookup, minus the raw
+/// tree-node-pointer return value (see [`award_mgr_detours`]'s doc comment on why that can't be
+/// reproduced, and why nothing needs it to be).
+pub fn get_award(id: i32) -> Option<AwardData> {
+    AWARD_MGR.lock().unwrap().awards.get(&id).cloned()
+}
+
+pub fn earned_ids() -> Vec<i32> {
+    AWARD_MGR.lock().unwrap().earned_ids.clone()
+}
+
+pub fn earned_count() -> i32 {
+    AWARD_MGR.lock().unwrap().earned_ids.len() as i32
+}
+
+/// Writes `value` as a single little-endian dword via the real vanilla `WriteBytesToFile`, shared by
+/// [`save`]. Duplicated per-file rather than shared, matching `ztthoughtmgr.rs`'s own precedent.
+fn write_dword(file: *const u32, value: u32) -> bool {
+    let bytes = value.to_le_bytes();
+    unsafe { WRITE_BYTES_TO_FILE.original()(bytes.as_ptr() as *const u32, 4, 1, file as *const i8) }
+}
+
+/// Reads a single little-endian dword via the real vanilla read primitive, shared by [`load`]. `None` on
+/// a short/failed read.
+fn read_dword(file: *const u32) -> Option<u32> {
+    let mut buf = 0u32;
+    let ok = unsafe { DEALLOCATE.original()(&mut buf as *mut u32 as *const u32, 4, 1, file as *const u8) };
+    (ok == 1).then_some(buf)
+}
+
+/// Reimplementation of `ZTAwardMgr::save`: writes the earned-id count, then every id, in that order.
+/// Every element is attempted regardless of an earlier write failing (matching
+/// `ZTAwardMgr_save.c`'s loop shape); the return value only reflects whether everything wrote
+/// successfully.
+pub fn save(file: *const u32) -> bool {
+    let ids = AWARD_MGR.lock().unwrap().earned_ids.clone();
+    let mut ok = write_dword(file, ids.len() as u32);
+    for id in ids {
+        ok &= write_dword(file, id as u32);
+    }
+    ok
+}
+
+/// Reimplementation of `ZTAwardMgr::load`: resets the earned-id vector, reads a count, then calls
+/// [`add_award`] per entry - re-running the sorted-unique insert for every loaded id (not a raw push), so
+/// a malformed/duplicate save can't reintroduce duplicates. Reproduces the exact on-disk wire format
+/// (`i32` count + `i32[count]`) byte-for-byte.
+pub fn load(file: *const u32) -> bool {
+    AWARD_MGR.lock().unwrap().earned_ids.clear();
+    let Some(count) = read_dword(file) else { return false };
+    let mut ok = true;
+    for _ in 0..count {
+        match read_dword(file) {
+            Some(id) => add_award(id as i32),
+            None => ok = false,
+        }
+    }
+    ok
+}
+
+/// Loads and parses a resource-relative `.cfg` path, matching `ztresearch.rs`'s
+/// `research_config_reimplementation::read_cfg` precedent exactly (vanilla's real `;`-only comment
+/// convention, not this codebase's own more lenient mod-loader parsing).
+fn read_cfg(path: &str) -> Option<Ini> {
+    let Some((_, data)) = get_file(path) else {
+        error!("ztawardmgr: resource '{path}' not found");
+        return None;
+    };
+    let text = decode_game_text(&data);
+    let mut ini = Ini::new_cs();
+    ini.set_comment_symbols(&[';']);
+    match ini.read(text) {
+        Ok(_) => Some(ini),
+        Err(e) => {
+            error!("ztawardmgr: failed to parse '{path}': {e}");
+            None
+        }
+    }
+}
+
+/// All values for a repeated key, dropping any that trim to empty - see
+/// `ztresearch.rs`'s `research_config_reimplementation::values` for why this (not `Ini::get_vec` directly)
+/// matches `BFConfigFile::addKeyVal`'s real behavior.
+fn values(ini: &Ini, section: &str, key: &str) -> Vec<String> {
+    ini.get_vec(section, key).unwrap_or_default().into_iter().filter(|v| !v.trim().is_empty()).collect()
+}
+
+/// `BFConfigFile::getString`/`getInt` return the *first* value for a repeated key, unlike `Ini::get`'s
+/// last-wins semantics - see `ztresearch.rs`'s `research_config_reimplementation::first`.
+fn first(ini: &Ini, section: &str, key: &str) -> Option<String> {
+    values(ini, section, key).into_iter().next()
+}
+
+fn first_parse<T: std::str::FromStr>(ini: &Ini, section: &str, key: &str) -> Option<T> {
+    first(ini, section, key)?.parse().ok()
+}
+
+/// Reimplementation of `ZTAwardMgr::start`'s resource parse. `BFResource::find(this, "award", ".cfg")`
+/// (per `ZTAwardMgr_start.c`) is a **multi-file** lookup, not a single fixed path - confirmed live: this
+/// codebase's real `awards/` resource directory holds several distinct `award*.cfg` files
+/// (`awards/awards.cfg`, `awards/award001.cfg`, `awards/award002.cfg`, `awards/award003.cfg`), and only
+/// the three `award0NN.cfg` files carry the `id`/`nameID`/`tooltipID`/`icon`-bearing catalogue data,
+/// gated behind a `[Version]` section - `awards/awards.cfg` itself is a different, unrelated small file
+/// (an `[Awards]` section with a bare `award=`/`maxCurrent=` pair, no `[Version]` section at all), which
+/// `ZTAwardMgr_start.c`'s own version-gate (`getInt(this, Version, version, &local_78)`, only proceeding
+/// if `local_78 > 0`) correctly skips. Since `resource_manager::lazyresourcemap`'s `LAZY_RESOURCE_MAP` is
+/// keyed by exact lowercased filename (collapsing same-named files across archives to one, but not
+/// collapsing *distinct* filenames), every matching name is enumerated here directly via
+/// `get_file_names()` and filtered by basename prefix `"award"`/suffix `".cfg"`, reproducing vanilla's
+/// multi-file search without needing a dedicated prefix-search primitive in the resource layer.
+///
+/// For each matching file (in enumeration order - unlike a single unique-key resource lookup, there's no
+/// natural "first/last wins" ordering across separate files, and none is needed: every real award id is
+/// only ever defined once, in exactly one qualifying file), checks a `[Version]` section's `version` key
+/// is present and positive (skipping the file otherwise - this is what correctly excludes
+/// `awards/awards.cfg`, which has no `[Version]` section at all), then reads the repeated `award` key from
+/// the `[Awards]` section. **Confirmed live against the real files** (not assumed from the decompile's own
+/// symbolic-looking `Version`/`Awards` argument names, which turned out to name *sections*, not
+/// `[default]`-section keys, and whose actual per-file key is the lowercase singular `award`/`version` -
+/// see `ZTAWARDMGR_START` in `reimplementation_tests/mod.rs`). Each `award` value is itself a section name
+/// (in practice just the id's own decimal digits, e.g. `13`) whose `id`/`nameID`/`tooltipID`/`icon` keys
+/// are read via the 4-arg form. Only inserted when `id != 0 && nameID != 0` (matching
+/// `ZTAwardMgr_start.c:65`); a later section with the same `id` overwrites an earlier one (the tree-insert
+/// itself is unconditional overwrite-by-id, not first-wins).
+pub fn start() -> bool {
+    let candidates: Vec<String> = crate::resource_manager::lazyresourcemap::get_file_names()
+        .into_iter()
+        .filter(|name| {
+            let base = name.rsplit('/').next().unwrap_or(name).to_ascii_lowercase();
+            base.starts_with("award") && base.ends_with(".cfg")
+        })
+        .collect();
+
+    let mut state = AWARD_MGR.lock().unwrap();
+    let mut any = false;
+    for path in candidates {
+        let Some(ini) = read_cfg(&path) else { continue };
+        let version: i32 = first_parse(&ini, "Version", "version").unwrap_or_default();
+        if version <= 0 {
+            continue;
+        }
+        for section in values(&ini, "Awards", "award") {
+            let id: i32 = first_parse(&ini, &section, "id").unwrap_or_default();
+            let name_id: i32 = first_parse(&ini, &section, "nameID").unwrap_or_default();
+            if id != 0 && name_id != 0 {
+                let tooltip_id = first_parse(&ini, &section, "tooltipID").unwrap_or_default();
+                let icon = first(&ini, &section, "icon").unwrap_or_default();
+                state.awards.insert(id, AwardData { name_id, tooltip_id, icon });
+                any = true;
+            }
+        }
+    }
+    any
+}
+
+/// The `ZTGameMgr` field offsets `ZTScenarioSimpleGoal::eval`'s case `0xb` reads directly, per
+/// `ZTScenarioSimpleGoal_eval.c:52-53` - both fall inside `ztgamemgr.rs`'s existing `pad9` gap, so no
+/// struct changes are needed; their true meaning is unconfirmed and out of scope here.
+const GOAL_KIND_OFFSET: u32 = 0xc;
+const GOAL_SUBMETRIC_OFFSET: u32 = 0x10;
+const GOAL_THRESHOLD_OFFSET: u32 = 0x1c;
+const AWARD_COUNT_SUBMETRIC: i32 = 0xb;
+const NUMERIC_STAT_GOAL_KIND: i32 = 1;
+
+fn elapsed_metric(game_mgr_ptr: u32) -> i32 {
+    get_from_memory::<i32>(game_mgr_ptr + 0x15c) + get_from_memory::<i32>(game_mgr_ptr + 0x160) * 12
+}
+
+/// Pure gate for `ZTScenarioSimpleGoal::eval`'s case `0xb` arm, isolated for testing without touching
+/// live memory. Matches `ZTScenarioSimpleGoal_eval.c` lines 44-94: goal kind `1` (`mbr_0xc`), submetric
+/// `0xb` (`mbr_0x10`), a live `GLOBAL_ZTGameMgr`, and the goal's threshold (`mbr_0x1c`) already reached.
+fn should_report_award_count(kind: i32, submetric: i32, threshold: i32, game_mgr_ptr: u32, elapsed: i32) -> bool {
+    kind == NUMERIC_STAT_GOAL_KIND && submetric == AWARD_COUNT_SUBMETRIC && game_mgr_ptr != 0 && threshold <= elapsed
+}
+
+/// Registers this module's live detours: `ZTAwardMgr`'s own methods, the `ZTScenarioSimpleGoal::eval`
+/// partial override, and `_showAwards`.
+pub fn init() {
+    award_mgr_detours::init();
+    eval_award_count_override::init();
+    show_awards_detour::init();
+}
+
+/// Detours `ZTAwardMgr`'s five own methods onto the free functions above.
+///
+/// **`GET_AWARD`'s return value**: vanilla's real return is a raw pointer into its own tree-node memory,
+/// which nothing in the Rust store has an equivalent for. The only confirmed external consumers are
+/// `_showAwards` (reimplemented in [`show_awards_detour`], which calls [`get_award`] directly rather than
+/// going through this detour's return value) and `ZTScenarioSimpleGoal::trigger06` (only checks
+/// `!= 0`/`== 0`, per `ZTScenarioSimpleGoal_trigger06.c:13-14`, never dereferences it). So this detour
+/// returns a fixed non-null sentinel (`1`) when found and `0` when not - **never dereference this return
+/// value**.
+mod award_mgr_detours {
+    use openzt_detour::generated::ztawardmgr::{ADD_AWARD, GET_AWARD, LOAD, SAVE, START};
+    use openzt_detour_macro::detour_mod;
+    use tracing::error;
+
+    #[detour_mod]
+    mod detours {
+        use super::*;
+
+        #[detour(ADD_AWARD)]
+        unsafe extern "thiscall" fn add_award(_this: *const u32, id: i32) {
+            crate::ztawardmgr::add_award(id);
+        }
+
+        #[detour(GET_AWARD)]
+        unsafe extern "thiscall" fn get_award(_this: *const u32, id: i32) -> i32 {
+            if crate::ztawardmgr::get_award(id).is_some() {
+                1
+            } else {
+                0
+            }
+        }
+
+        #[detour(SAVE)]
+        unsafe extern "thiscall" fn save(_this: *const u32, file: *const i8) -> u32 {
+            crate::ztawardmgr::save(file as *const u32) as u32
+        }
+
+        /// `_version` is unused - `ZTAwardMgr_load.c`'s own body never reads its 3rd formal parameter -
+        /// but `ZTWorldMgr_load.c`'s real call site genuinely pushes 3 arguments and `generated.rs`
+        /// declares 3, so this must be kept in the signature purely to keep the thiscall stack-cleanup
+        /// arithmetic correct.
+        #[detour(LOAD)]
+        unsafe extern "thiscall" fn load(_this: *const u32, file: *const u32, _version: u32) -> u32 {
+            crate::ztawardmgr::load(file) as u32
+        }
+
+        #[detour(START)]
+        unsafe extern "thiscall" fn start(_this: *const u32) -> u32 {
+            crate::ztawardmgr::start() as u32
+        }
+    }
+
+    pub fn init() {
+        if let Err(e) = unsafe { detours::init_detours() } {
+            error!("Failed to initialise ztawardmgr own-method detours: {e:?}");
+        }
+    }
+}
+
+/// Partial-override detour for `ZTScenarioSimpleGoal::eval`'s case `0xb` arm - the only other place
+/// (besides `_showAwards`) that reads `ZTAwardMgr`'s raw fields directly. Everything else about this
+/// large, mostly-unrelated switch is left as vanilla via `EVAL_DETOUR.call(this)` - see
+/// `resource_manager/hooks.rs`'s `zoo_ui_general_get_info_image_name` for the same
+/// match-one-condition/call-through-otherwise shape.
+mod eval_award_count_override {
+    use openzt_detour::generated::ztscenariosimplegoal::EVAL;
+    use openzt_detour_macro::detour_mod;
+    use tracing::error;
+
+    use super::*;
+
+    #[detour_mod]
+    mod detours {
+        use super::*;
+
+        #[detour(EVAL)]
+        unsafe extern "thiscall" fn eval(this: *const u32) -> i32 {
+            let kind = get_from_memory::<i32>(this as u32 + GOAL_KIND_OFFSET);
+            let submetric = get_from_memory::<i32>(this as u32 + GOAL_SUBMETRIC_OFFSET);
+            let threshold = get_from_memory::<i32>(this as u32 + GOAL_THRESHOLD_OFFSET);
+            let game_mgr_ptr = globals().ztgamemgr_ptr() as u32;
+            let elapsed = if game_mgr_ptr != 0 { elapsed_metric(game_mgr_ptr) } else { 0 };
+            if should_report_award_count(kind, submetric, threshold, game_mgr_ptr, elapsed) {
+                return crate::ztawardmgr::earned_count();
+            }
+            unsafe { EVAL_DETOUR.call(this) }
+        }
+    }
+
+    pub fn init() {
+        if let Err(e) = unsafe { detours::init_detours() } {
+            error!("Failed to initialise ztscenariosimplegoal eval award-count override detour: {e:?}");
+        }
+    }
+}
+
+/// Reimplementation of the free function `_showAwards`, which iterates `ZTAwardMgr`'s earned-id vector
+/// directly (bypassing any method call) to populate a `UIListBox`. `GLOBAL_BFUIMgr`'s RVA (`0x0023_8de0`)
+/// is the same one `ztthoughtmgr.rs`'s `thought_ui_detours::global_bfuimgr` already uses.
+mod show_awards_detour {
+    use openzt_detour::generated::{
+        bfuimgr::GET_ELEMENT_0,
+        standalone::SHOW_AWARDS,
+        uilistbox::{ADD_STRING_0, CLEAR},
+    };
+    use openzt_detour_macro::detour_mod;
+    use tracing::error;
+
+    use super::*;
+    use crate::encoding_utils::encode_to_ansi;
+
+    const AWARDS_LIST_ELEMENT_ID: i32 = 0x101c;
+    const AWARD_LIST_ITEM_COLOR: u32 = 0x00ff_00ff;
+
+    fn global_bfuimgr() -> *const u32 {
+        (get_module_base("zoo.exe") as u32 + 0x0023_8de0) as *const u32
+    }
+
+    /// Builds temporary buffers for `text`/`icon` and hands them to the real `UIListBox::addString`,
+    /// mirroring `_showAwards.c`'s exact argument mapping: `icon` is passed as the raw `p2` slot (the
+    /// award's value-payload `+0x1c` dword directly - **not** a `ZTBufferString` wrapper, unlike `text`),
+    /// `p5` is `0xffffffff` (not null), and `color` is
+    /// `((tooltip_id as u32) & 0xff00_0000) | AWARD_LIST_ITEM_COLOR` - implemented exactly this way
+    /// (not pre-simplified to the bare literal) so a live comparison can confirm the top byte of a real
+    /// `tooltip_id` is always `0` in practice, per this module's own doc comment on that open question.
+    #[allow(clippy::manual_dangling_ptr)] // literal sentinel value `1`, not a real pointer
+    fn add_award_to_list_box(list_box: *const u32, text: &str, icon: &str, tooltip_id: i32) {
+        let mut encoded_text = encode_to_ansi(text);
+        let text_len = encoded_text.len() as u32;
+        encoded_text.push(0);
+        let text_start = encoded_text.as_ptr() as u32;
+        let text_buffer = ZTBufferString::from_raw_parts(text_start, text_start + text_len, text_start + encoded_text.len() as u32);
+
+        let mut encoded_icon = encode_to_ansi(icon);
+        encoded_icon.push(0);
+        let icon_ptr = encoded_icon.as_ptr();
+
+        let color = ((tooltip_id as u32) & 0xff00_0000) | AWARD_LIST_ITEM_COLOR;
+
+        unsafe {
+            ADD_STRING_0.original()(
+                list_box,
+                &text_buffer as *const ZTBufferString as *const u32,
+                icon_ptr as *const i32,
+                std::ptr::null(),
+                std::ptr::null(),
+                0xffffffffu32 as *const i32,
+                0,
+                1 as *const i32,
+                color,
+                tooltip_id as u32 as *const i32,
+            );
+        }
+    }
+
+    #[detour_mod]
+    mod detours {
+        use super::*;
+
+        #[detour(SHOW_AWARDS)]
+        unsafe extern "stdcall" fn show_awards() {
+            let element = unsafe { GET_ELEMENT_0.original()(global_bfuimgr(), AWARDS_LIST_ELEMENT_ID) };
+            if element.is_null() {
+                return;
+            }
+            unsafe { CLEAR.original()(element) };
+            for id in crate::ztawardmgr::earned_ids() {
+                let Some(award) = crate::ztawardmgr::get_award(id) else { continue };
+                let Some(text) = load_string_by_id(award.name_id() as u32) else { continue };
+                add_award_to_list_box(element, &text, award.icon(), award.tooltip_id());
+            }
+        }
+    }
+
+    pub fn init() {
+        if let Err(e) = unsafe { detours::init_detours() } {
+            error!("Failed to initialise ztawardmgr show_awards detour: {e:?}");
+        }
+    }
+}
+
+/// Live-comparison test support for `reimplementation_tests`. Unlike `ZTThoughtMgr`, there's no
+/// standalone-instance capability here - the constructor hardcodes the global address `0x006390e8` inside
+/// its own body - so every test drives the one real live singleton via [`real_ptr`], resetting it between
+/// cases rather than building/freeing a fresh instance.
+#[cfg(feature = "reimplementation-tests")]
+pub(crate) mod live_support {
+    use super::*;
+
+    /// RVA of the real singleton `GLOBAL_ZTAwardMgr` embedded object (`0x006390e8` raw VA minus the
+    /// `0x400000` preferred base).
+    const GLOBAL_ZTAWARDMGR_RVA: u32 = 0x0023_90e8;
+
+    pub(crate) fn real_ptr() -> *const u32 {
+        (get_module_base("zoo.exe") as u32 + GLOBAL_ZTAWARDMGR_RVA) as *const u32
+    }
+
+    /// Resets the Rust-side reimplemented store to empty - test-only, since production code has no
+    /// dedicated "clear" entry point (there's only ever one real singleton, never destroyed).
+    pub(crate) fn reset_reimplemented_store() {
+        let mut state = AWARD_MGR.lock().unwrap();
+        state.earned_ids.clear();
+        state.awards.clear();
+    }
+
+    /// The Rust-side catalogue as `(id, name_id, tooltip_id)` triples, in ascending-id order (`BTreeMap`
+    /// iteration order) - matching [`read_vanilla_award_tree`]'s in-order walk, for direct comparison.
+    pub(crate) fn reimplemented_award_triples() -> Vec<(i32, i32, i32)> {
+        AWARD_MGR.lock().unwrap().awards.iter().map(|(&id, a)| (id, a.name_id, a.tooltip_id)).collect()
+    }
+
+    /// Read-only in-order walk of the real vanilla rb-tree rooted at the live singleton's `+0x0` header
+    /// pointer, using the node layout confirmed in `private/docs/vtables/ZTAwardMgr.md` (`_Left`/`_Right`
+    /// at `+0x8`/`+0xc`, key at `+0x10`, `nameID`/`tooltipID` at `+0x14`/`+0x18`). Never mutates or frees
+    /// anything - safe regardless of which allocator built the nodes.
+    pub(crate) fn read_vanilla_award_tree() -> Vec<(i32, i32, i32)> {
+        let header = get_from_memory::<u32>(real_ptr() as u32);
+        let root = get_from_memory::<u32>(header + 4);
+        let mut result = Vec::new();
+        walk_tree(root, &mut result);
+        result
+    }
+
+    fn walk_tree(node: u32, out: &mut Vec<(i32, i32, i32)>) {
+        if node == 0 {
+            return;
+        }
+        walk_tree(get_from_memory::<u32>(node + 8), out);
+        let key = get_from_memory::<i32>(node + 0x10);
+        let name_id = get_from_memory::<i32>(node + 0x14);
+        let tooltip_id = get_from_memory::<i32>(node + 0x18);
+        out.push((key, name_id, tooltip_id));
+        walk_tree(get_from_memory::<u32>(node + 0xc), out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_sorted_unique_keeps_vector_descending_and_deduped() {
+        let mut ids = Vec::new();
+        for id in [5, 1, 3, 1, 5, 2] {
+            insert_sorted_unique(&mut ids, id);
+        }
+        assert_eq!(ids, vec![5, 3, 2, 1]);
+    }
+
+    #[test]
+    fn insert_sorted_unique_matches_live_observed_ordering() {
+        // Confirmed live via ZTAWARDMGR_ADD_AWARD_SAVE_LOAD: adding [0, -1] in that order leaves the
+        // real vanilla vector as [0, -1], not the ascending [-1, 0].
+        let mut ids = Vec::new();
+        insert_sorted_unique(&mut ids, 0);
+        insert_sorted_unique(&mut ids, -1);
+        assert_eq!(ids, vec![0, -1]);
+    }
+
+    #[test]
+    fn should_report_award_count_requires_every_condition() {
+        assert!(should_report_award_count(1, 0xb, 10, 0x1000, 10));
+        assert!(should_report_award_count(1, 0xb, 10, 0x1000, 20));
+        assert!(!should_report_award_count(0, 0xb, 10, 0x1000, 10), "wrong goal kind");
+        assert!(!should_report_award_count(1, 0xa, 10, 0x1000, 10), "wrong submetric");
+        assert!(!should_report_award_count(1, 0xb, 10, 0, 10), "null game mgr");
+        assert!(!should_report_award_count(1, 0xb, 11, 0x1000, 10), "threshold not yet reached");
+    }
+}

--- a/openzt/src/ztguest.rs
+++ b/openzt/src/ztguest.rs
@@ -1,0 +1,169 @@
+//! Reimplementations of `ZTGuest`'s three megatile-reading methods -
+//! `fCrowdDensityMegatile`/`fEstheticBonusMegatile`/`fStinkyMegatile`. These were, until this module
+//! existed, the last vanilla code that read `ZTMegatileMgr`'s grid directly, by pointer-chasing, bypassing
+//! any detour (see `ztmegatilemgr.rs`'s module doc comment) - closing this read loop is a prerequisite for
+//! `openzt/plans/native-data-structures-plan.md`'s Module 2 (migrating `ZTMegatileMgr`'s storage to native
+//! `Vec`/`HashMap`), which this module deliberately does not attempt: `ZTMegatileMgr`'s struct layout must
+//! still stay byte-exact for now, since the accessors this file calls
+//! (`megatile()`/`guest_count()`/`stink()`/`category_value()`) still read vanilla's own live-owned memory,
+//! not a migrated Rust store.
+//!
+//! No Windows decompile exists for any of the three, nor for their sole caller,
+//! `ZTGuest::doEnvironmentEffectCheck` (only macOS decompiles were available previously) - all four
+//! addresses used here were confirmed by direct disassembly of `zoo.dll` instead. See
+//! `private/docs/vtables/ZTGuest.md`'s "Non-virtual confirmed methods" section for the full evidence chain
+//! (call-site uniqueness, the `ZTGuestType::environment_effect_check`/`crowded_viewing_threshold`/
+//! `object_esthetic_threshold`/`stink_threshold` field-offset matches, and the `GLOBAL_ZTMegatileMgr`/
+//! `MegatileRow`/`ZTMegatile` stride matches).
+
+use std::mem;
+
+use openzt_detour::generated::ztguest::{F_CROWD_DENSITY_MEGATILE, F_ESTHETIC_BONUS_MEGATILE, F_STINKY_MEGATILE};
+use openzt_detour_macro::detour_mod;
+use tracing::error;
+
+use crate::{
+    globals::globals,
+    util::{get_from_memory, ref_from_memory},
+    ztmapview::BFTile,
+    ztmegatilemgr::ZTMegatile,
+    ztworldmgr::BFEntity,
+};
+
+/// Shared tile-to-megatile lookup for all three methods below: `ZTMegatile`s are indexed by `x/5`, `y/5`
+/// (see `ztmegatilemgr.rs`'s own `recalculate_characteristics` doc comment for the same indexing), and a
+/// negative tile coordinate (never real in practice, but not representable as the `usize` the accessor
+/// takes) is treated the same as an out-of-range one: `None`.
+fn tile_megatile(tile: &BFTile) -> Option<&'static ZTMegatile> {
+    if tile.pos.x < 0 || tile.pos.y < 0 {
+        return None;
+    }
+    globals().ztmegatilemgr().megatile((tile.pos.x / 5) as usize, (tile.pos.y / 5) as usize)
+}
+
+/// `ZTGuest::fCrowdDensityMegatile` (`0x0043b7e3`). Confirmed by the MSVC magic-constant (`0x51eb851f`)
+/// division idiom at the tail of the real function, applied to the megatile's `guest_count` field
+/// (offset `0x0`) - matching the mac decompile's own `guest_count()*10/25` formula exactly. `0` for a
+/// tile with no allocated megatile, matching vanilla's own implicit "empty tile" behavior.
+pub fn crowd_density_megatile(tile: &BFTile) -> i32 {
+    tile_megatile(tile).map_or(0, |m| m.guest_count() * 10 / 25)
+}
+
+/// `ZTGuest::fStinkyMegatile` (`0x0043b84a`). Reads the megatile's `stink` scalar (formerly mislabeled
+/// `esthetic_bonus` - see `ztmegatilemgr.rs`'s `ZTMegatile::stink`/finding 2 in
+/// `ztmegatilemgr-review-findings.md`), confirmed by the real function loading
+/// `ZTMegatile+0x10` (`fld dword ptr [eax+edx*4+0x10]`) and comparing the result against
+/// `ZTGuestType::stink_threshold` (`bfentitytype.rs`, offset `0x2B0`). `0.0` for a tile with no allocated
+/// megatile.
+pub fn stinky_megatile(tile: &BFTile) -> f32 {
+    tile_megatile(tile).map_or(0.0, |m| m.stink())
+}
+
+/// `ZTGuest::fEstheticBonusMegatile` (`0x0043b6c0`). Looks up `this`'s own entity type's category id (via
+/// [`entity_category_id`]) in the megatile's `category_map` (`ZTMegatile::category_value`) - confirmed by
+/// the real function's virtual call through the entity type's vtable slot `+0x20`, then a red-black-tree
+/// search matching `category_map`'s existing shape, then a comparison of the found value against
+/// `ZTGuestType::object_esthetic_threshold` (`bfentitytype.rs`, offset `0x2A4`). `0.0` for a tile with no
+/// allocated megatile, or a category id with no entry in that megatile's map - vanilla's own
+/// find-or-fail-then-`fld` idiom would return whatever the FPU stack happened to hold on a failed lookup,
+/// a case never actually hit in practice since every real entity type has a populated category before a
+/// guest ever calls this; `0.0` is a well-defined, safer stand-in for that unreachable branch.
+pub fn esthetic_bonus_megatile(this: &BFEntity, tile: &BFTile) -> f32 {
+    let Some(megatile) = tile_megatile(tile) else {
+        return 0.0;
+    };
+    megatile.category_value(entity_category_id(this)).unwrap_or(0.0)
+}
+
+/// Calls `entity`'s own entity type's vtable slot `+0x20` - confirmed `ZTGuestType::0x00401fb7`
+/// (`private/docs/vtables/ZTGuestType.md`), a trivial `mov eax,[ecx+0x130]; ret` getter - to resolve the
+/// category id [`esthetic_bonus_megatile`] looks up. Same vtable-slot call-through shape as
+/// `ztmegatilemgr::entity_type_matches`.
+///
+/// Offset `0x130` on a `ZTGuestType`/`ZTUnitType` instance is also exactly `BFUnitType::name_id`
+/// (`bfentitytype.rs:765`, a string resource id, not obviously a `BFCategory`-style category id in the
+/// `0x251f..0x2523` range `recalculate_characteristics` populates the map with) - this may be a genuine
+/// "category id" field that happens to share `name_id`'s slot by coincidence of this project's own field
+/// naming, or evidence the vtable-slot identification needs another look. Not asserted as settled; the
+/// live `ZTGUEST_MEGATILE_METHODS_LIVE` comparison in `reimplementation_tests` is the actual verification
+/// for this call, not this doc comment.
+fn entity_category_id(entity: &BFEntity) -> i32 {
+    let entity_type_ptr = *entity.inner_class_ptr();
+    let vtable = get_from_memory::<u32>(entity_type_ptr);
+    let get_category_id_fn = unsafe { mem::transmute::<u32, extern "thiscall" fn(u32) -> i32>(get_from_memory::<u32>(vtable + 0x20)) };
+    get_category_id_fn(entity_type_ptr)
+}
+
+#[detour_mod]
+mod detours {
+    use super::*;
+
+    #[detour(F_CROWD_DENSITY_MEGATILE)]
+    unsafe extern "thiscall" fn f_crowd_density_megatile(this: *const u32) -> i32 {
+        let entity = unsafe { ref_from_memory::<BFEntity>(this) };
+        let Some(tile) = entity.get_tile() else {
+            return 0;
+        };
+        crowd_density_megatile(&tile)
+    }
+
+    #[detour(F_STINKY_MEGATILE)]
+    unsafe extern "thiscall" fn f_stinky_megatile(this: *const u32) -> f32 {
+        let entity = unsafe { ref_from_memory::<BFEntity>(this) };
+        let Some(tile) = entity.get_tile() else {
+            return 0.0;
+        };
+        stinky_megatile(&tile)
+    }
+
+    #[detour(F_ESTHETIC_BONUS_MEGATILE)]
+    unsafe extern "thiscall" fn f_esthetic_bonus_megatile(this: *const u32) -> f32 {
+        let entity = unsafe { ref_from_memory::<BFEntity>(this) };
+        let Some(tile) = entity.get_tile() else {
+            return 0.0;
+        };
+        esthetic_bonus_megatile(entity, &tile)
+    }
+}
+
+/// Registers this module's live detours.
+pub fn init() {
+    if let Err(e) = unsafe { detours::init_detours() } {
+        error!("Failed to initialise ztguest detours: {e:?}");
+    }
+}
+
+/// Live-comparison test support for `reimplementation_tests`.
+#[cfg(feature = "reimplementation-tests")]
+pub(crate) mod live_support {
+    use super::*;
+    use crate::bfentitytype::ZTEntityTypeClass;
+
+    /// Finds every live `ZTGuest` in the world's entity array (via `BFEntity::entity_type_class()`, the
+    /// same coarse type check `list_entities`/`get_zt_world_mgr_entities` already use elsewhere),
+    /// returning each one's raw pointer and current tile - so a live comparison can sample the whole
+    /// live population (different tiles, different megatiles, different entity-type category ids)
+    /// instead of just whichever guest happens to be first in the array. Empty if no guest is currently
+    /// on a resolvable tile (e.g. an empty/guest-less save, or a save loaded before any guest has
+    /// spawned).
+    pub(crate) fn find_live_guests() -> Vec<(u32, BFTile)> {
+        let world = globals().ztworldmgr();
+        let mut addr = world.entity_array_start();
+        let end = world.entity_array_end();
+        let mut guests = Vec::new();
+        while addr < end {
+            let entity_ptr = get_from_memory::<u32>(addr);
+            if entity_ptr != 0 {
+                let entity = unsafe { ref_from_memory::<BFEntity>(entity_ptr) };
+                if entity.entity_type_class() == ZTEntityTypeClass::Guest
+                    && let Some(tile) = entity.get_tile()
+                {
+                    guests.push((entity_ptr, tile));
+                }
+            }
+
+            addr += 4;
+        }
+        guests
+    }
+}

--- a/openzt/src/ztmarketing.rs
+++ b/openzt/src/ztmarketing.rs
@@ -4,9 +4,11 @@
 //! `cost` dollars per in-game day.
 //!
 //! The funding-level mutators (`increase_funding`/`decrease_funding`/`set_funding_level`), `update`,
-//! `save`/`load`, `getFundingText`, and the `.cfg`-driven config-loading pipeline
-//! (`marketing_config_reimplementation`, below) are all natively reimplemented. Only
-//! `ZTMarketingMgr::create`/`instantiate`/`destroy` remain unreimplemented.
+//! `save`/`load`, `getFundingText`, the `.cfg`-driven config-loading pipeline
+//! (`marketing_config_reimplementation`, below), and the vtable destructor (`marketing_dtor_detour`,
+//! below) are all natively reimplemented. Only `ZTMarketingMgr::create`/`instantiate` (construction, not
+//! teardown) remain unreimplemented - `ztmarketingmgr::CONSTRUCTOR`/`CREATE_ZTMARKETING_MGR` in
+//! `generated.rs` are the confirmed addresses, just not yet redirected onto a Rust-side allocation path.
 
 use std::mem::size_of;
 
@@ -761,6 +763,14 @@ mod marketing_config_reimplementation {
             }
         }
 
+        /// The destructor body: frees the owned `ZTMarketing` (and its funding table) exactly like
+        /// `clear_configurations`, since there's nothing left to tear down beyond what that method
+        /// already does. Never frees `self` (`this`) itself - see `marketing_dtor_detour`'s doc comment
+        /// for why.
+        pub(crate) fn destroy(&mut self) {
+            self.clear_configurations();
+        }
+
         /// Always calls `clear_configurations` first, then bails out (returning `false`, with
         /// `marketing_ptr` left dangling) if the top-level file can't be opened. Otherwise allocates a
         /// fresh, default `ZTMarketing`, attaches it to `marketing_ptr` immediately, reads the
@@ -836,11 +846,50 @@ mod marketing_config_reimplementation {
     }
 }
 
+/// Detours `ZTMarketingMgr`'s vtable destructor slot - the scalar deleting destructor at `0x00504f89`
+/// (`ZTMARKETING_MGR_1` in `generated.rs`) - onto [`ZTMarketingMgr::destroy`]. Vanilla's own version of
+/// this function calls the real destructor body (`ZTMARKETING_MGR_0`, `0x00504f73`), then conditionally
+/// calls `operator delete` on `this` if the caller-supplied flag byte's low bit is set. Left undetoured,
+/// that real body runs `operator delete` on `marketing_ptr` - the funding-table buffer and `ZTMarketing`
+/// struct our own `marketing_config_reimplementation` allocates through Rust's global allocator - the
+/// same cross-allocator hazard CLAUDE.md's "Live Reimplementation-Comparison Tests" section documents
+/// for `ZTThoughtMgr`. Since `ZTMarketingMgr` is a process-lifetime singleton and no address for the real
+/// vanilla `operator delete` this class would use is known or needed, this reimplementation only ever
+/// frees the funding table and the `Box`-allocated `ZTMarketing`, never the flag-gated `this` itself.
+/// `ZTMARKETING_MGR_0` (the real destructor body's own address, only ever reached indirectly through
+/// this wrapper) is intentionally left un-detoured: nothing else in vanilla calls it directly.
+mod marketing_dtor_detour {
+    use openzt_detour::generated::ztmarketingmgr::ZTMARKETING_MGR_1;
+    use openzt_detour_macro::detour_mod;
+    use tracing::error;
+
+    use super::*;
+    use crate::util::mut_from_memory;
+
+    #[detour_mod]
+    mod detours {
+        use super::*;
+
+        #[detour(ZTMARKETING_MGR_1)]
+        unsafe extern "thiscall" fn ztmarketingmgr_dtor(this: *const u32, _flags: u8) -> *const u32 {
+            unsafe { mut_from_memory::<ZTMarketingMgr>(this) }.destroy();
+            this
+        }
+    }
+
+    pub fn init() {
+        if let Err(e) = unsafe { detours::init_detours() } {
+            error!("Failed to initialise ztmarketingmgr destructor detour: {e:?}");
+        }
+    }
+}
+
 /// registers the marketing module's live detours
 pub fn init() {
     marketing_save_reimplementation::init();
     marketing_config_reimplementation::init();
     marketing_update_reimplementation::init();
+    marketing_dtor_detour::init();
 }
 
 /// Synthetic `ZTMarketing` construction/teardown for the live `reimplementation_tests` comparison

--- a/openzt/src/ztmegatilemgr.rs
+++ b/openzt/src/ztmegatilemgr.rs
@@ -1,8 +1,10 @@
 //! Structs and methods for the vanilla `ZTMegatileMgr`/`ZTMegatile` classes: terrain "megatile" (5x5
-//! tile block) characteristic recalculation - guest density and per-`BFCategory` "esthetic" averages,
-//! consumed by `ZTGuest::fCrowdDensityMegatile`/`fEstheticBonusMegatile` (not detoured by this file;
-//! they read this memory raw, by pointer-chasing, so the struct layout below must be byte-exact rather
-//! than merely behaviorally equivalent).
+//! tile block) characteristic recalculation - guest density, a per-tile `stink` scalar, and per-
+//! `BFCategory` "esthetic" averages, consumed by `ZTGuest::fCrowdDensityMegatile`/`fStinkyMegatile`/
+//! `fEstheticBonusMegatile` (now detoured in `ztguest.rs` onto Rust reimplementations that call this
+//! file's own accessors - see that module's doc comment). The struct layout below must still stay
+//! byte-exact rather than merely behaviorally equivalent: those accessors still read vanilla's own
+//! live-owned memory directly, not a migrated Rust store (see `native-data-structures-plan.md`'s Module 2).
 //!
 //! Allocator strategy: **100% vanilla-owned, everywhere in this file.** This module never allocates a
 //! single byte of its own. The outer `vector<vector<ZTMegatile>>` grid and every embedded
@@ -84,7 +86,9 @@ impl MegatileRow {
 pub struct ZTMegatile {
     guest_count: i32,        // 0x0 - zeroed then incremented per resident guest in recalc
     category_map: MapHeader, // 0x4-0xf - std::map<int,float>, see MapHeader/TreeNode below
-    esthetic_bonus: f32,     // 0x10 - running per-category esthetic-bonus average
+    stink: f32,              // 0x10 - running per-tile stink accumulator (formerly mislabeled
+                              // `esthetic_bonus` - see ztmegatilemgr-review-findings.md finding 2; the
+                              // real esthetic-bonus data is `category_map`/`category_value()`)
 }
 
 const _: () = assert!(mem::size_of::<ZTMegatile>() == 0x14);
@@ -137,8 +141,8 @@ impl ZTMegatile {
         self.guest_count
     }
 
-    pub fn esthetic_bonus(&self) -> f32 {
-        self.esthetic_bonus
+    pub fn stink(&self) -> f32 {
+        self.stink
     }
 
     /// Read-only BST lower-bound walk over `category_map`, mirroring
@@ -250,7 +254,7 @@ impl ZTMegatileMgr {
     /// `ZTMegatileMgr_recalculateCharacteristics.c`. Two passes over the live map:
     ///
     /// 1. Reset every currently-allocated megatile: `guest_count = 0`, `category_map.clear()` (via
-    ///    [`category_map_clear`]), `esthetic_bonus = 0.0`.
+    ///    [`category_map_clear`]), `stink = 0.0`.
     /// 2. For every real map tile `(x, y)`, walk its guest-occupant list (an intrusive circular list
     ///    whose sentinel pointer lives at the tile's own `+0x0`, node shape `{next, prev, entity_ptr}`)
     ///    counting residents whose entity type passes the `ZTGuestType` check
@@ -259,8 +263,8 @@ impl ZTMegatileMgr {
     ///    entity pointers (`+0x4`/`+0x8`/`+0xc`/`+0x10`) whose type passes the `ZTSceneryType`-ish check
     ///    (`DAT_00638670`), accumulates that entity type's per-category `BFCategory::getValue`
     ///    (`bfcategory::GET_VALUE`) divided by the entity's own footprint divisor (`+0x150`) into the
-    ///    owning megatile's `category_map`, plus its `esthetic_bonus`-source field (`+0x11c`) into
-    ///    `esthetic_bonus` the same way.
+    ///    owning megatile's `category_map`, plus its `stink`-source field (`+0x11c`) into `stink` the
+    ///    same way.
     ///
     /// Only the not-found branch of the per-category accumulation calls through to vanilla (the
     /// find-or-insert helper, [`accumulate_category_value`]) - once a node exists, writing its `value`
@@ -272,7 +276,7 @@ impl ZTMegatileMgr {
                 let megatile = unsafe { &mut *row.start.add(i) };
                 megatile.guest_count = 0;
                 unsafe { category_map_clear(&mut megatile.category_map) };
-                megatile.esthetic_bonus = 0.0;
+                megatile.stink = 0.0;
             }
         }
 
@@ -323,7 +327,7 @@ impl ZTMegatileMgr {
                         let delta = raw_value as f32 / divisor;
                         unsafe { accumulate_category_value(&mut megatile.category_map, category_id, delta) };
                     }
-                    megatile.esthetic_bonus += get_from_memory::<i32>(entity_type_ptr + 0x11c) as f32 / divisor;
+                    megatile.stink += get_from_memory::<i32>(entity_type_ptr + 0x11c) as f32 / divisor;
                 }
             }
         }
@@ -394,7 +398,7 @@ impl ZTMegatileMgr {
                 // construct-from-value call. A `category_map.head: null` within that value isn't safe
                 // either - see [`empty_category_map_sentinel`]'s own doc comment. The fill value needs a
                 // real empty-tree sentinel for `head` (`parent: null`, `left`/`right` self-referential).
-                let fill = ZTMegatile { guest_count: 0, category_map: MapHeader { head: empty_category_map_sentinel(), size: 0, _reserved: 0 }, esthetic_bonus: 0.0 };
+                let fill = ZTMegatile { guest_count: 0, category_map: MapHeader { head: empty_category_map_sentinel(), size: 0, _reserved: 0 }, stink: 0.0 };
                 unsafe {
                     inner_vector_insert_n(row, (inner_target - current_inner) as u32, &fill);
                 }
@@ -641,8 +645,8 @@ pub(crate) mod live_support {
         mgr.tick_accumulator = tick_accumulator;
     }
 
-    /// A snapshot of every currently-allocated megatile's `guest_count`/`esthetic_bonus`, plus the
-    /// grid's own shape (columns, rows-per-column) - the diff mechanism `ZTMEGATILEMGR_RECALCULATE_CHARACTERISTICS`
+    /// A snapshot of every currently-allocated megatile's `guest_count`/`stink`, plus the grid's own
+    /// shape (columns, rows-per-column) - the diff mechanism `ZTMEGATILEMGR_RECALCULATE_CHARACTERISTICS`
     /// uses to compare the real vanilla call against the reimplementation, since `category_map`'s raw
     /// tree contents aren't directly comparable field-by-field without the same lower-bound walk
     /// `category_value` already performs (used instead - see `snapshot_categories`).
@@ -655,7 +659,7 @@ pub(crate) mod live_support {
         let columns = (0..mgr.megatile_columns())
             .map(|column| (0..mgr.megatile_rows_in_column(column)).map(|row| {
                 let mt = mgr.megatile(column, row).expect("row within bounds");
-                (mt.guest_count(), mt.esthetic_bonus())
+                (mt.guest_count(), mt.stink())
             }).collect())
             .collect();
         GridSnapshot { columns }
@@ -748,8 +752,8 @@ mod tests {
     /// short-lived unit tests).
     fn fixture_mgr() -> ZTMegatileMgr {
         let megatiles: &'static mut [ZTMegatile] = Box::leak(Box::new([
-            ZTMegatile { guest_count: 3, category_map: MapHeader { head: std::ptr::null_mut(), size: 0, _reserved: 0 }, esthetic_bonus: 1.5 },
-            ZTMegatile { guest_count: 7, category_map: MapHeader { head: std::ptr::null_mut(), size: 0, _reserved: 0 }, esthetic_bonus: 2.5 },
+            ZTMegatile { guest_count: 3, category_map: MapHeader { head: std::ptr::null_mut(), size: 0, _reserved: 0 }, stink: 1.5 },
+            ZTMegatile { guest_count: 7, category_map: MapHeader { head: std::ptr::null_mut(), size: 0, _reserved: 0 }, stink: 2.5 },
         ]));
         let start = megatiles.as_mut_ptr();
         let end = unsafe { start.add(megatiles.len()) };
@@ -776,7 +780,7 @@ mod tests {
 
     #[test]
     fn category_value_on_empty_map_is_none() {
-        let mt = ZTMegatile { guest_count: 0, category_map: MapHeader { head: std::ptr::null_mut(), size: 0, _reserved: 0 }, esthetic_bonus: 0.0 };
+        let mt = ZTMegatile { guest_count: 0, category_map: MapHeader { head: std::ptr::null_mut(), size: 0, _reserved: 0 }, stink: 0.0 };
         assert_eq!(mt.category_value(9503), None);
     }
 
@@ -790,7 +794,7 @@ mod tests {
         root.right = &mut right as *mut TreeNode;
         let mut header = TreeNode { _color_isnil: 0, parent: &mut root as *mut TreeNode, left: std::ptr::null_mut(), right: std::ptr::null_mut(), key: 0, value: 0.0 };
         let map = MapHeader { head: &mut header as *mut TreeNode, size: 3, _reserved: 0 };
-        let mt = ZTMegatile { guest_count: 0, category_map: map, esthetic_bonus: 0.0 };
+        let mt = ZTMegatile { guest_count: 0, category_map: map, stink: 0.0 };
 
         assert_eq!(mt.category_value(9503), Some(1.0));
         assert_eq!(mt.category_value(9504), Some(2.0));

--- a/openzt/src/ztthoughtmgr.rs
+++ b/openzt/src/ztthoughtmgr.rs
@@ -1,16 +1,28 @@
 //! Structs and methods for the vanilla `ZTThoughtMgr`/`ZTThought` classes, which track the "thought
 //! bubble" messages guests/animals display over their heads (e.g. "caught prey", template string id
-//! `0x280a`) - a simple, small `BFMgr`-derived class owning a single intrusive, sentinel-terminated
-//! linked list of `ZTThought` records.
+//! `0x280a`) - a simple, small `BFMgr`-derived class that vanilla implements as a single intrusive,
+//! sentinel-terminated linked list of `ZTThought` records.
 //!
-//! Unlike `ZTResearchMgr`/`ZTMarketingMgr`, the persistent list and the UI's temporary output lists
-//! both use vanilla's own small-object freelist allocator, which has no confirmed Windows address for
-//! its low-level alloc/free helpers. This module's list is therefore *exclusively* Rust-owned
-//! (`Box`-allocated nodes) from the point OpenZT loads onward - the only vanilla-allocated survivor is
-//! the original sentinel node `CreateZTThoughtMgr` allocates at startup (left un-detoured), which the
-//! list helpers below must never attempt to free.
+//! The persistent list itself lives in a plain Rust `VecDeque<ZTThought>`, held in the process-global
+//! [`THOUGHT_STORES`] registry keyed by each `ZTThoughtMgr` instance's own `sentinel_ptr` field.
+//! `sentinel_ptr` is never repurposed or dereferenced by our own code anymore - it's left exactly as
+//! vanilla's `CreateZTThoughtMgr` constructor set it, purely so its value stays a stable, unique
+//! per-instance key (real singleton or test standalone alike) without needing a second identity
+//! mechanism. All four mutators (`addThought`/`removeThoughtsBy{Thinker,Object,Habitat}`), save/load, and
+//! the destructor are detoured onto Rust methods that operate on this store.
+//!
+//! The three read-only accessors (`getThoughtsBy{Thinker,Object,Habitat}`) are also detoured - see
+//! [`thought_accessor_detours`] - but only to log an error if they're ever actually invoked (no known
+//! caller reaches them) before falling through to the real vanilla body via `.original()`. That fallback
+//! stays safe post-migration specifically *because* `sentinel_ptr` is left untouched: vanilla reads a
+//! genuine, permanently self-referencing (i.e. permanently empty) sentinel node, so the fallback can only
+//! ever report zero matches, never dereference stale or incompatible memory.
 
-use std::mem;
+use std::{
+    collections::{HashMap, VecDeque},
+    mem,
+    sync::{LazyLock, Mutex},
+};
 
 use openzt_detour::generated::standalone::{DEALLOCATE, WRITE_BYTES_TO_FILE};
 
@@ -318,187 +330,87 @@ fn read_dword(file: *const u32) -> Option<u32> {
     (ok == 1).then_some(buf)
 }
 
-/// A persistent-list node: 8 bytes of intrusive links followed by the `ZTThought` payload at `+0x8`.
-/// The sentinel node vanilla allocates at startup shares this same link layout (its `data` is never
-/// read).
-#[repr(C)]
-struct ThoughtNode {
-    next: *mut ThoughtNode,
-    prev: *mut ThoughtNode,
-    data: ZTThought,
-}
-
-/// Borrowing iterator over `ZTThoughtMgr`'s persistent list, front (most-recently-inserted) to back,
-/// skipping the sentinel. Returned as `impl Iterator` from `ZTThoughtMgr::iter` so this type itself
-/// never needs to be public.
-struct ThoughtIter<'a> {
-    sentinel: *const ThoughtNode,
-    current: *const ThoughtNode,
-    _marker: std::marker::PhantomData<&'a ZTThoughtMgr>,
-}
-
-impl<'a> Iterator for ThoughtIter<'a> {
-    type Item = &'a ZTThought;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.current == self.sentinel {
-            return None;
-        }
-        let node = unsafe { &*self.current };
-        self.current = node.next;
-        Some(&node.data)
-    }
-}
-
-/// Mutable counterpart to [`ThoughtIter`], used by `ZTThoughtMgr::populate_thoughts`.
-struct ThoughtIterMut<'a> {
-    sentinel: *mut ThoughtNode,
-    current: *mut ThoughtNode,
-    _marker: std::marker::PhantomData<&'a mut ZTThoughtMgr>,
-}
-
-impl<'a> Iterator for ThoughtIterMut<'a> {
-    type Item = &'a mut ZTThought;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.current == self.sentinel {
-            return None;
-        }
-        let node = unsafe { &mut *self.current };
-        self.current = node.next;
-        Some(&mut node.data)
-    }
-}
+/// Process-global registry backing every `ZTThoughtMgr` instance's persistent list, keyed by that
+/// instance's own `sentinel_ptr` value (see the module doc comment for why that field, rather than the
+/// struct's own address, is the identity key). There is exactly one key in real gameplay - the live
+/// singleton's `sentinel_ptr` - but tests build multiple independent standalone instances, each with its
+/// own distinct (leaked) sentinel allocation, so this must support more than one entry.
+static THOUGHT_STORES: LazyLock<Mutex<HashMap<u32, VecDeque<ZTThought>>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
 
 impl ZTThoughtMgr {
     pub fn max_thoughts(&self) -> u32 {
         self.max_thoughts
     }
 
-    fn sentinel(&self) -> *mut ThoughtNode {
-        self.sentinel_ptr as *mut ThoughtNode
+    /// This instance's key into [`THOUGHT_STORES`] - its own `sentinel_ptr`, never dereferenced as a
+    /// pointer by any of the methods below.
+    fn store_key(&self) -> u32 {
+        self.sentinel_ptr
     }
 
-    /// Walks the persistent thought list front-to-back (most-recently-inserted first), skipping the
-    /// sentinel node.
-    pub fn iter(&self) -> impl Iterator<Item = &ZTThought> {
-        let sentinel = self.sentinel() as *const ThoughtNode;
-        let current = unsafe { (*sentinel).next as *const ThoughtNode };
-        ThoughtIter { sentinel, current, _marker: std::marker::PhantomData }
-    }
-
-    /// Mutable counterpart to `iter` - used by `populate_thoughts`.
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut ZTThought> {
-        let sentinel = self.sentinel();
-        let current = unsafe { (*sentinel).next };
-        ThoughtIterMut { sentinel, current, _marker: std::marker::PhantomData }
+    /// Walks the persistent thought list front-to-back (most-recently-inserted first), yielding owned
+    /// copies (`ZTThought` is `Copy`) - the store itself lives behind a lock scoped to this call, so
+    /// nothing can borrow out of it.
+    pub fn iter(&self) -> impl Iterator<Item = ZTThought> {
+        THOUGHT_STORES.lock().unwrap().get(&self.store_key()).into_iter().flatten().copied().collect::<Vec<_>>().into_iter()
     }
 
     pub fn len(&self) -> usize {
-        self.iter().count()
+        THOUGHT_STORES.lock().unwrap().get(&self.store_key()).map_or(0, VecDeque::len)
     }
 
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    /// Splices `thought` in as a new `Box`-owned node at the front of the list, uncapped.
-    fn link_front(&mut self, thought: ZTThought) {
-        let sentinel = self.sentinel();
-        let old_front = unsafe { (*sentinel).next };
-        let node = Box::into_raw(Box::new(ThoughtNode { next: old_front, prev: sentinel, data: thought }));
-        unsafe {
-            (*old_front).prev = node;
-            (*sentinel).next = node;
-        }
-    }
-
-    /// Splices `thought` in as a new `Box`-owned node at the *back* of the list, uncapped - what
-    /// `ZTThoughtMgr::load` builds on (the opposite end from `link_front`).
-    fn link_back(&mut self, thought: ZTThought) {
-        let sentinel = self.sentinel();
-        let old_back = unsafe { (*sentinel).prev };
-        let node = Box::into_raw(Box::new(ThoughtNode { next: sentinel, prev: old_back, data: thought }));
-        unsafe {
-            (*old_back).next = node;
-            (*sentinel).prev = node;
-        }
-    }
-
-    /// Inserts `thought` as a new `Box`-owned node at the front of the list (matching `addThought`'s
-    /// own insertion point - most-recent-first), then trims from the back until the list is at most
-    /// `max_thoughts` long, freeing every trimmed node.
+    /// Inserts `thought` at the front of the list (matching `addThought`'s own insertion point -
+    /// most-recent-first), then trims from the back until the list is at most `max_thoughts` long.
     pub(crate) fn insert_front(&mut self, thought: ZTThought) {
-        self.link_front(thought);
-        self.trim_to_cap();
-    }
-
-    fn trim_to_cap(&mut self) {
-        while self.len() > self.max_thoughts as usize {
-            let sentinel = self.sentinel();
-            let last = unsafe { (*sentinel).prev };
-            if last == sentinel {
-                break;
-            }
-            self.unlink_and_free(last);
+        let mut stores = THOUGHT_STORES.lock().unwrap();
+        let store = stores.entry(self.store_key()).or_default();
+        store.push_front(thought);
+        while store.len() > self.max_thoughts as usize {
+            store.pop_back();
         }
     }
 
-    /// Unlinks `node` from the list and frees it as a `Box`. `node` must be a real (non-sentinel) node
-    /// currently linked into this list.
-    fn unlink_and_free(&mut self, node: *mut ThoughtNode) {
-        unsafe {
-            let prev = (*node).prev;
-            let next = (*node).next;
-            (*prev).next = next;
-            (*next).prev = prev;
-            drop(Box::from_raw(node));
-        }
-    }
-
-    /// Removes and frees every node whose `ZTThought` matches `predicate`, never touching the
-    /// sentinel. Shared removal primitive for `removeThoughtsBy{Thinker,Habitat,Object}`.
+    /// Removes every thought matching `predicate`. Shared removal primitive for
+    /// `removeThoughtsBy{Thinker,Habitat,Object}`.
     pub(crate) fn remove_where(&mut self, predicate: impl Fn(&ZTThought) -> bool) {
-        let sentinel = self.sentinel();
-        let mut current = unsafe { (*sentinel).next };
-        while current != sentinel {
-            let next = unsafe { (*current).next };
-            if predicate(unsafe { &(*current).data }) {
-                self.unlink_and_free(current);
-            }
-            current = next;
+        if let Some(store) = THOUGHT_STORES.lock().unwrap().get_mut(&self.store_key()) {
+            store.retain(|t| !predicate(t));
         }
     }
 
     /// Minus the vanilla temporary-`std::list` construction the decompile builds and then immediately
-    /// frees again - a `Vec` collected directly from `iter()` is a drop-in behavioral replacement for
+    /// frees again - a `Vec` collected directly from the store is a drop-in behavioral replacement for
     /// what every caller actually consumes: an ordered, `max_count`-bounded sequence of matching
     /// `ZTThought`s.
     ///
-    /// Selection walks `iter()`'s own front-to-back (most-recently-added-first) order with a
-    /// `max_count`-then-stop cap, but the final returned order is oldest-of-the-selected-first, the
-    /// reverse of the walk/selection order - hence the explicit `.reverse()` below.
+    /// Selection walks front-to-back (most-recently-added-first) order with a `max_count`-then-stop cap,
+    /// but the final returned order is oldest-of-the-selected-first, the reverse of the walk/selection
+    /// order - hence the explicit `.reverse()` below.
     ///
     /// Matches on `thinker_ptr` (the resolved live pointer), not `thinker_id` - vanilla itself never
     /// compares against the persisted id here.
-    pub fn get_thoughts_by_thinker(&self, thinker_ptr: u32, max_count: usize) -> Vec<&ZTThought> {
-        let mut matches: Vec<&ZTThought> = self.iter().filter(|t| t.thinker_ptr() == thinker_ptr).take(max_count).collect();
+    pub fn get_thoughts_by_thinker(&self, thinker_ptr: u32, max_count: usize) -> Vec<ZTThought> {
+        let mut matches: Vec<ZTThought> = self.iter().filter(|t| t.thinker_ptr() == thinker_ptr).take(max_count).collect();
         matches.reverse();
         matches
     }
 
     /// See `get_thoughts_by_thinker`'s doc comment for the shared reasoning, including why the result
     /// is reversed after selection. Matches on `object_ptr`.
-    pub fn get_thoughts_by_object(&self, object_ptr: u32, max_count: usize) -> Vec<&ZTThought> {
-        let mut matches: Vec<&ZTThought> = self.iter().filter(|t| t.object_ptr() == object_ptr).take(max_count).collect();
+    pub fn get_thoughts_by_object(&self, object_ptr: u32, max_count: usize) -> Vec<ZTThought> {
+        let mut matches: Vec<ZTThought> = self.iter().filter(|t| t.object_ptr() == object_ptr).take(max_count).collect();
         matches.reverse();
         matches
     }
 
     /// See `get_thoughts_by_thinker`'s doc comment for the shared reasoning, including why the result
     /// is reversed after selection. Matches on `habitat_ptr`.
-    pub fn get_thoughts_by_habitat(&self, habitat_ptr: u32, max_count: usize) -> Vec<&ZTThought> {
-        let mut matches: Vec<&ZTThought> = self.iter().filter(|t| t.habitat_ptr() == habitat_ptr).take(max_count).collect();
+    pub fn get_thoughts_by_habitat(&self, habitat_ptr: u32, max_count: usize) -> Vec<ZTThought> {
+        let mut matches: Vec<ZTThought> = self.iter().filter(|t| t.habitat_ptr() == habitat_ptr).take(max_count).collect();
         matches.reverse();
         matches
     }
@@ -526,22 +438,21 @@ impl ZTThoughtMgr {
     /// Unlike `remove_where`-based removal, this doesn't just remove matches: for every thought whose
     /// `habitat_ptr` matches, if `force` is `false` *and* the thought still has a live `object_ptr`,
     /// only the habitat link is cleared (`habitat_ptr = 0`) and the thought itself survives; otherwise
-    /// (a forced removal, or the thought has no object of its own to keep it alive) the node is fully
-    /// unlinked and freed.
+    /// (a forced removal, or the thought has no object of its own to keep it alive) the thought is
+    /// removed outright.
     pub fn remove_thoughts_by_habitat(&mut self, habitat_ptr: u32, force: bool) {
-        let sentinel = self.sentinel();
-        let mut current = unsafe { (*sentinel).next };
-        while current != sentinel {
-            let next = unsafe { (*current).next };
-            let node = unsafe { &mut *current };
-            if node.data.habitat_ptr == habitat_ptr {
-                if !force && node.data.object_ptr != 0 {
-                    node.data.habitat_ptr = 0;
-                } else {
-                    self.unlink_and_free(current);
+        if let Some(store) = THOUGHT_STORES.lock().unwrap().get_mut(&self.store_key()) {
+            store.retain_mut(|t| {
+                if t.habitat_ptr != habitat_ptr {
+                    return true;
                 }
-            }
-            current = next;
+                if !force && t.object_ptr != 0 {
+                    t.habitat_ptr = 0;
+                    true
+                } else {
+                    false
+                }
+            });
         }
     }
 
@@ -558,8 +469,8 @@ impl ZTThoughtMgr {
 
     /// Reads a leading dword count (interpreted as signed - a failed or negative/zero count leaves the
     /// list untouched and returns immediately). For each of `count` records, default-constructs a
-    /// fresh `ZTThought` and calls `ZTThought::load` on it. A record is only spliced into the list (via
-    /// `link_back` - `load` itself never trims to `max_thoughts`, unlike `addThought`) if the read
+    /// fresh `ZTThought` and calls `ZTThought::load` on it. A record is only appended to the list (at
+    /// the back - `load` itself never trims to `max_thoughts`, unlike `addThought`) if the read
     /// succeeded *and* every non-zero id it carries actually resolved to a live pointer (for
     /// `version >= 0x1e` streams, where `ZTThought::load` already attempted that resolution inline); a
     /// record whose reference no longer resolves is silently dropped. Surviving records end up in read
@@ -574,12 +485,14 @@ impl ZTThoughtMgr {
         }
 
         let mut ok = true;
+        let mut stores = THOUGHT_STORES.lock().unwrap();
+        let store = stores.entry(self.store_key()).or_default();
         for _ in 0..count {
             let mut thought = ZTThought::new(0, 0, 0, 0);
             let loaded_ok = thought.load(file, version);
             ok &= loaded_ok;
             if loaded_ok && (thought.object_id == 0 || thought.object_ptr != 0) && (thought.thinker_id == 0 || thought.thinker_ptr != 0) {
-                self.link_back(thought);
+                store.push_back(thought);
             }
         }
         ok
@@ -589,28 +502,106 @@ impl ZTThoughtMgr {
     /// `ZTWorldMgr::load` for a specific pre-`0x1e` save-version range - not part of `ZTThoughtMgr::load`
     /// itself, which only performs this resolution inline for `version >= 0x1e` streams.
     pub fn populate_thoughts(&mut self) {
-        for thought in self.iter_mut() {
-            thought.populate();
+        if let Some(store) = THOUGHT_STORES.lock().unwrap().get_mut(&self.store_key()) {
+            for thought in store.iter_mut() {
+                thought.populate();
+            }
         }
     }
 
-    /// Vanilla's destructor calls a `std::list` "erase whole range" helper over the list, i.e. destroys
-    /// and frees every real node - `remove_where(|_| true)` is exactly that, reusing the same
-    /// `Box`-freeing primitive every other mutator does. The sentinel node and the `ZTThoughtMgr`
-    /// struct itself are never freed here, matching vanilla.
+    /// Vanilla's destructor destroys and frees every real node in the list. `clear` is the Rust-side
+    /// equivalent: drop every entry from this instance's store, without touching the sentinel or the
+    /// `ZTThoughtMgr` struct itself, matching vanilla.
     pub fn clear(&mut self) {
-        self.remove_where(|_| true);
+        if let Some(store) = THOUGHT_STORES.lock().unwrap().get_mut(&self.store_key()) {
+            store.clear();
+        }
     }
 }
 
-/// Registers this module's live detours: the UI-consumer detours, the mutator detours
-/// (`addThought`/`removeThoughtsBy{Thinker,Object,Habitat}`), the save/load-family detours
-/// (`save`/`load`/`populateThoughts`), and the destructor detour.
+/// Registers this module's live detours: the UI-consumer detours, the raw-accessor observability
+/// detours, the mutator detours (`addThought`/`removeThoughtsBy{Thinker,Object,Habitat}`), the
+/// save/load-family detours (`save`/`load`/`populateThoughts`), and the destructor detour.
 pub fn init() {
     thought_ui_detours::init();
+    thought_accessor_detours::init();
     thought_mutator_detours::init();
     thought_save_detours::init();
     thought_dtor_detour::init();
+}
+
+/// Detours `ZTThoughtMgr`'s three read-only accessors - `getThoughtsBy{Thinker,Object,Habitat}` - purely
+/// for observability, not behavior. An exhaustive search of the decompiled call-graph corpus in
+/// `private/resources/decompiles` found exactly three callers of these three addresses:
+/// `_fillListBox_0`/`_fillListBox_1`/`_refillThoughtsList` - and all three are already fully replaced by
+/// [`thought_ui_detours`], which calls the `Vec`-returning `get_thoughts_by_*` methods directly and never
+/// invokes `.original()` on any of these three. So as far as this codebase can confirm, nothing live ever
+/// reaches these detours at all.
+///
+/// If some other, undiscovered caller *does* still exist, reimplementing these accessors properly would
+/// mean synthesizing a vanilla-shaped output `std::list<ZTThought>` into the caller's out-param - but the
+/// caller itself (per `_fillListBox_0.c`/`_fillListBox_1.c`/`_refillThoughtsList.c`) tears that list down
+/// afterward using vanilla's own *inlined* freelist push, not a call we could intercept. Any output list
+/// we built via `Box` would then be freed through vanilla's freelist - the exact cross-allocator heap
+/// corruption CLAUDE.md warns about - and there's no confirmed Windows address for the generic small-object
+/// allocator that would let us build a genuinely vanilla-freeable list instead. Given zero known callers,
+/// that work isn't justified: each detour here just logs (so a real hit would actually get noticed) and
+/// falls through to `.original()`, which is safe *by construction* - it only reads `this`'s own
+/// `sentinel_ptr`, which the module's `VecDeque` migration deliberately leaves pointing at a genuine,
+/// permanently self-referencing (i.e. permanently empty) vanilla sentinel node. Worst case, an
+/// undiscovered caller sees an always-empty result - a cosmetic gap, never a crash.
+mod thought_accessor_detours {
+    use openzt_detour::generated::ztthoughtmgr::{GET_THOUGHTS_BY_HABITAT, GET_THOUGHTS_BY_OBJECT, GET_THOUGHTS_BY_THINKER};
+    use openzt_detour_macro::detour_mod;
+    use tracing::error;
+
+    #[detour_mod]
+    mod detours {
+        use super::*;
+
+        /// `max_count` is declared `*const i32` in `generated.rs`, but per
+        /// `ZTThoughtMgr_getThoughtsByObject.c` it's actually passed by value (a Ghidra type-inference
+        /// artifact on this parameter, unlike `getThoughtsByThinker`'s correctly-inferred `i32`) - logged
+        /// via a raw cast back to `i32`, never dereferenced.
+        #[detour(GET_THOUGHTS_BY_OBJECT)]
+        unsafe extern "thiscall" fn get_thoughts_by_object(this: *const u32, out: *const i32, object_ptr: *const i32, max_count: *const i32) -> *const i32 {
+            error!(
+                "GET_THOUGHTS_BY_OBJECT invoked directly (this={this:p}, object_ptr={object_ptr:p}, max_count={}) - no known caller should reach \
+                 this anymore now that ZTThoughtMgr's persistent list lives in a Rust-side store; falling through to the real vanilla body, which \
+                 will report zero matches against the permanently-empty sentinel it still reads",
+                max_count as i32
+            );
+            unsafe { GET_THOUGHTS_BY_OBJECT.original()(this, out, object_ptr, max_count) }
+        }
+
+        /// See `get_thoughts_by_object`'s doc comment re: `max_count`'s pointer typing.
+        #[detour(GET_THOUGHTS_BY_HABITAT)]
+        unsafe extern "thiscall" fn get_thoughts_by_habitat(this: *const u32, out: *const i32, habitat_ptr: *const i32, max_count: *const i32) -> *const i32 {
+            error!(
+                "GET_THOUGHTS_BY_HABITAT invoked directly (this={this:p}, habitat_ptr={habitat_ptr:p}, max_count={}) - no known caller should \
+                 reach this anymore now that ZTThoughtMgr's persistent list lives in a Rust-side store; falling through to the real vanilla body, \
+                 which will report zero matches against the permanently-empty sentinel it still reads",
+                max_count as i32
+            );
+            unsafe { GET_THOUGHTS_BY_HABITAT.original()(this, out, habitat_ptr, max_count) }
+        }
+
+        #[detour(GET_THOUGHTS_BY_THINKER)]
+        unsafe extern "thiscall" fn get_thoughts_by_thinker(this: *const u32, out: *const i32, thinker_ptr: *const i32, max_count: i32) -> *const i32 {
+            error!(
+                "GET_THOUGHTS_BY_THINKER invoked directly (this={this:p}, thinker_ptr={thinker_ptr:p}, max_count={max_count}) - no known caller \
+                 should reach this anymore now that ZTThoughtMgr's persistent list lives in a Rust-side store; falling through to the real vanilla \
+                 body, which will report zero matches against the permanently-empty sentinel it still reads"
+            );
+            unsafe { GET_THOUGHTS_BY_THINKER.original()(this, out, thinker_ptr, max_count) }
+        }
+    }
+
+    pub fn init() {
+        if let Err(e) = unsafe { detours::init_detours() } {
+            error!("Failed to initialise ztthoughtmgr raw-accessor observability detours: {e:?}");
+        }
+    }
 }
 
 /// Detours the three UI functions that used to be `getThoughtsBy*`'s only consumers of the vanilla
@@ -889,13 +880,29 @@ mod thought_dtor_detour {
     }
 }
 
-/// Live-comparison test support for `reimplementation_tests` - builds/tears down standalone,
-/// heap-allocated `ZTThoughtMgr`/`ZTThought` instances not spliced into the real singleton, and wraps
-/// vanilla-allocated temporary list output for reading. Nothing here ever frees vanilla-allocated
-/// memory through `Box`, or `Box`-allocated memory through vanilla's own freelist.
+/// Live-comparison test support for `reimplementation_tests`. Since the production `ZTThoughtMgr`
+/// methods no longer touch `sentinel_ptr`'s raw memory at all (the persistent list lives in
+/// [`THOUGHT_STORES`] instead), the live-comparison suite needs a *separate*, explicit way to drive and
+/// read a genuine vanilla-shaped `ThoughtNode` chain - this module provides both: the registry-based
+/// helpers production code also uses (`build_standalone_mgr`/`destroy_standalone_mgr`), and a set of
+/// `*_raw_chain*` helpers that operate directly on `sentinel_ptr`'s intrusive chain, for seeding/reading
+/// instances a test drives through a real, undetoured `.original()` call.
+///
+/// Nothing here ever frees vanilla-allocated memory through `Box`, or `Box`-allocated memory through
+/// vanilla's own freelist - see each function's own doc comment for which allocator it assumes.
 #[cfg(feature = "reimplementation-tests")]
 pub(crate) mod live_support {
     use super::*;
+
+    /// A persistent-list node: 8 bytes of intrusive links followed by the `ZTThought` payload at `+0x8`.
+    /// The sentinel node vanilla allocates at startup shares this same link layout (its `data` is never
+    /// read). Test-only: no production code walks this layout anymore.
+    #[repr(C)]
+    pub(crate) struct ThoughtNode {
+        next: *mut ThoughtNode,
+        prev: *mut ThoughtNode,
+        data: ZTThought,
+    }
 
     /// Builds a `ZTThought` with every field directly settable - unlike `ZTThought::new`, which
     /// dereferences `thinker_ptr`/`object_ptr`/`habitat_arg` when non-null to resolve
@@ -920,9 +927,14 @@ pub(crate) mod live_support {
         ZTThought { vtable, string_id, thinker_id, object_id, tile_x, tile_y, thinker_ptr, object_ptr, habitat_ptr }
     }
 
-    /// Builds a standalone `ZTThoughtMgr` with a freshly heap-allocated, self-referencing sentinel node
-    /// - not spliced into the real singleton. Heap-allocates the `ZTThoughtMgr` itself too (returned as
-    /// a raw pointer, for passing to real vanilla `.original()()` calls).
+    /// Builds a standalone `ZTThoughtMgr` with a freshly heap-allocated, self-referencing sentinel node,
+    /// never spliced into the real singleton. Heap-allocates the `ZTThoughtMgr` itself too (returned as
+    /// a raw pointer, for passing to real vanilla `.original()()` calls). The sentinel is a genuine,
+    /// self-referencing `ThoughtNode` (not just an opaque placeholder): any real, undetoured vanilla call
+    /// against this instance (`ADD_THOUGHT.original()`, `GET_THOUGHTS_BY_THINKER.original()`, ...) reads
+    /// `sentinel_ptr` as a real intrusive-list pointer and needs it to be one. Reimplemented-side methods
+    /// never dereference it, only using its value as a [`THOUGHT_STORES`] key, so the exact same
+    /// construction is safe and sufficient for both real and reimplemented standalone instances.
     pub(crate) fn build_standalone_mgr(max_thoughts: u32) -> *mut ZTThoughtMgr {
         let sentinel = Box::into_raw(Box::new(ThoughtNode {
             next: std::ptr::null_mut(),
@@ -936,48 +948,115 @@ pub(crate) mod live_support {
         Box::into_raw(Box::new(ZTThoughtMgr { vtable: 0, flag: 0, _pad: [0; 3], sentinel_ptr: sentinel as u32, max_thoughts }))
     }
 
-    /// Frees every real node (via `clear`, the same primitive the real destructor detour uses), then
-    /// the sentinel node and the `ZTThoughtMgr` allocation itself.
+    /// Splices `thought` in as a new `Box`-owned node at the front of `mgr`'s *raw* `sentinel_ptr`
+    /// chain, bypassing [`THOUGHT_STORES`] entirely - use this to seed the "real" side of a live
+    /// comparison that will drive `mgr` through a genuine, undetoured `.original()` call (which reads
+    /// `sentinel_ptr` directly and knows nothing about our Rust-side store).
+    pub(crate) fn seed_raw_chain(mgr: &ZTThoughtMgr, thought: ZTThought) {
+        let sentinel = mgr.sentinel_ptr as *mut ThoughtNode;
+        let old_front = unsafe { (*sentinel).next };
+        let node = Box::into_raw(Box::new(ThoughtNode { next: old_front, prev: sentinel, data: thought }));
+        unsafe {
+            (*old_front).prev = node;
+            (*sentinel).next = node;
+        }
+    }
+
+    /// Walks a raw, sentinel-terminated `ThoughtNode` chain starting from `sentinel_ptr`, front-to-back,
+    /// returning owned copies. Used both for `mgr`'s own persistent-list chain (via [`read_raw_chain`])
+    /// and for a vanilla-allocated temporary output list a `getThoughtsBy*` `.original()` call wrote its
+    /// sentinel into (the two share the same node layout, only the allocator differs). Never mutates or
+    /// frees anything - safe regardless of which allocator produced the chain.
+    pub(crate) fn read_raw_chain_from_sentinel(sentinel_ptr: u32) -> Vec<ZTThought> {
+        let sentinel = sentinel_ptr as *const ThoughtNode;
+        let mut result = Vec::new();
+        let mut current = unsafe { (*sentinel).next as *const ThoughtNode };
+        while current != sentinel {
+            result.push(unsafe { (*current).data });
+            current = unsafe { (*current).next };
+        }
+        result
+    }
+
+    /// See [`read_raw_chain_from_sentinel`]. Convenience wrapper for reading `mgr`'s own persistent-list
+    /// chain directly (as opposed to a separate temporary output list's sentinel).
+    pub(crate) fn read_raw_chain(mgr: &ZTThoughtMgr) -> Vec<ZTThought> {
+        read_raw_chain_from_sentinel(mgr.sentinel_ptr)
+    }
+
+    /// Frees every `Box`-owned node currently in `mgr`'s raw chain, without touching the sentinel. Safe
+    /// only when every node presently linked is genuinely `Box`-owned - i.e. `mgr` was seeded via
+    /// [`seed_raw_chain`], and any `.original()` call made against it since only *removed* nodes (which
+    /// vanilla frees via its own freelist push, already gone from the chain by the time this walks it) or
+    /// mutated fields in place, never *allocated* new ones. Never call this after a call that could have
+    /// allocated (`ADD_THOUGHT`/`LOAD`) - see [`destroy_standalone_mgr_leaking_nodes`] for that case.
+    fn free_raw_chain_nodes(mgr: &ZTThoughtMgr) {
+        let sentinel = mgr.sentinel_ptr as *mut ThoughtNode;
+        let mut current = unsafe { (*sentinel).next };
+        while current != sentinel {
+            let next = unsafe { (*current).next };
+            drop(unsafe { Box::from_raw(current) });
+            current = next;
+        }
+    }
+
+    /// Tears down a standalone instance whose raw chain holds only `Box`-owned nodes (see
+    /// [`free_raw_chain_nodes`]) and which was never registered in [`THOUGHT_STORES`] - i.e. a "real"
+    /// comparison instance seeded via [`seed_raw_chain`] and driven only through `.original()` calls that
+    /// remove/mutate but never allocate.
+    pub(crate) fn free_raw_chain_mgr(ptr: *mut ZTThoughtMgr) {
+        if ptr.is_null() {
+            return;
+        }
+        let mgr = unsafe { &*ptr };
+        free_raw_chain_nodes(mgr);
+        drop(unsafe { Box::from_raw(mgr.sentinel_ptr as *mut ThoughtNode) });
+        drop(unsafe { Box::from_raw(ptr) });
+    }
+
+    /// Tears down a standalone instance seeded on *both* sides at once (see `seed_thoughts_both` in the
+    /// live-comparison suite) - i.e. its raw chain holds `Box`-owned nodes (safe to free per
+    /// [`free_raw_chain_nodes`]) *and* it has a [`THOUGHT_STORES`] entry from also being driven through a
+    /// reimplemented-method call. Frees both representations, then the sentinel and the struct itself.
+    pub(crate) fn destroy_standalone_mgr_both(ptr: *mut ZTThoughtMgr) {
+        if ptr.is_null() {
+            return;
+        }
+        let mgr = unsafe { &*ptr };
+        free_raw_chain_nodes(mgr);
+        THOUGHT_STORES.lock().unwrap().remove(&mgr.store_key());
+        drop(unsafe { Box::from_raw(mgr.sentinel_ptr as *mut ThoughtNode) });
+        drop(unsafe { Box::from_raw(ptr) });
+    }
+
+    /// Tears down a standalone instance driven only through reimplemented methods (its data, if any,
+    /// lives entirely in [`THOUGHT_STORES`] - its raw chain was never linked into and stays a bare,
+    /// self-referencing sentinel). Removes the store entry, then frees the sentinel and the struct.
     pub(crate) fn destroy_standalone_mgr(ptr: *mut ZTThoughtMgr) {
         if ptr.is_null() {
             return;
         }
-        let mgr = unsafe { &mut *ptr };
-        mgr.clear();
-        drop(unsafe { Box::from_raw(mgr.sentinel()) });
+        let mgr = unsafe { &*ptr };
+        THOUGHT_STORES.lock().unwrap().remove(&mgr.store_key());
+        drop(unsafe { Box::from_raw(mgr.sentinel_ptr as *mut ThoughtNode) });
         drop(unsafe { Box::from_raw(ptr) });
     }
 
     /// Frees only the sentinel node and the `ZTThoughtMgr` allocation itself, without walking/freeing
-    /// any linked list nodes - use this instead of `destroy_standalone_mgr` whenever real vanilla code
-    /// (the real, undetoured `ADD_THOUGHT`/`LOAD`) may have linked nodes it allocated through vanilla's
-    /// own small-object freelist into this manager's list: those nodes must never be freed through
-    /// `Box` (a cross-allocator free is undefined behavior / heap corruption), so this deliberately
-    /// leaks them - a one-time, per-proptest-case leak, reclaimed at process exit. The sentinel node
-    /// itself is still safe to free normally here: `ADD_THOUGHT`/`LOAD` only ever relink its
-    /// `next`/`prev` fields to point at newly inserted nodes, never reallocate or hand its own address
-    /// to the freelist.
+    /// any raw-chain nodes - use this instead of `free_raw_chain_mgr` whenever real vanilla code (the
+    /// real, undetoured `ADD_THOUGHT`/`LOAD`) may have linked nodes it allocated through vanilla's own
+    /// small-object freelist into this manager's list: those nodes must never be freed through `Box` (a
+    /// cross-allocator free is undefined behavior / heap corruption), so this deliberately leaks them - a
+    /// one-time, per-proptest-case leak, reclaimed at process exit. The sentinel node itself is still
+    /// safe to free normally here: `ADD_THOUGHT`/`LOAD` only ever relink its `next`/`prev` fields to
+    /// point at newly inserted nodes, never reallocate or hand its own address to the freelist.
     pub(crate) fn destroy_standalone_mgr_leaking_nodes(ptr: *mut ZTThoughtMgr) {
         if ptr.is_null() {
             return;
         }
         let mgr = unsafe { &*ptr };
-        drop(unsafe { Box::from_raw(mgr.sentinel()) });
+        drop(unsafe { Box::from_raw(mgr.sentinel_ptr as *mut ThoughtNode) });
         drop(unsafe { Box::from_raw(ptr) });
-    }
-
-    /// Wraps a vanilla-allocated sentinel pointer - the out-param `getThoughtsBy*` writes - as a
-    /// throwaway `ZTThoughtMgr` purely so `.iter()` can walk it. The temporary list's own sentinel is
-    /// self-referencing and its matched-entry nodes are `{next, prev, ZTThought}` at stride `0x2c` -
-    /// byte-for-byte identical to our own `ThoughtNode`/persistent-list shape; only the allocator
-    /// differs (vanilla's own small-object freelist, never `Box`). Never call any mutating method
-    /// (`insert_front`/`remove_where`/`clear`/...) on the result - freeing or writing through
-    /// `Box`-shaped assumptions here would corrupt the freelist heap. The vanilla list itself is
-    /// deliberately never freed by this test harness - there's no confirmed address for the freelist's
-    /// own free-node routine - a one-time, per-proptest-case leak of a handful of `0x2c`-byte nodes,
-    /// reclaimed at process exit.
-    pub(crate) fn read_only_wrap_vanilla_list(sentinel_ptr: u32) -> ZTThoughtMgr {
-        ZTThoughtMgr { vtable: 0, flag: 0, _pad: [0; 3], sentinel_ptr, max_thoughts: u32::MAX }
     }
 }
 
@@ -1013,20 +1092,16 @@ mod tests {
         }
     }
 
-    /// Builds a standalone `ZTThoughtMgr` with a freshly heap-allocated, self-referencing sentinel
-    /// node - never spliced into the real singleton. Leaks the sentinel (acceptable for short-lived
-    /// unit tests).
+    /// Builds a standalone `ZTThoughtMgr` backed by its own entry in [`THOUGHT_STORES`] - never spliced
+    /// into the real singleton. `sentinel_ptr` is never dereferenced by any production method anymore;
+    /// it's just a unique registry key here, so a plain leaked one-byte allocation is enough (no need
+    /// for a real `ThoughtNode`-shaped placeholder, which is test-only harness scoped to the
+    /// `reimplementation-tests` feature these plain unit tests don't enable). Leaks that placeholder
+    /// (acceptable for short-lived unit tests, and guarantees the key is never reused across tests
+    /// sharing a stack slot).
     fn build_test_mgr(max_thoughts: u32) -> ZTThoughtMgr {
-        let sentinel = Box::into_raw(Box::new(ThoughtNode {
-            next: std::ptr::null_mut(),
-            prev: std::ptr::null_mut(),
-            data: thought_fixture(0, 0),
-        }));
-        unsafe {
-            (*sentinel).next = sentinel;
-            (*sentinel).prev = sentinel;
-        }
-        ZTThoughtMgr { vtable: 0, flag: 0, _pad: [0; 3], sentinel_ptr: sentinel as u32, max_thoughts }
+        let sentinel_ptr = Box::into_raw(Box::new(0u8)) as u32;
+        ZTThoughtMgr { vtable: 0, flag: 0, _pad: [0; 3], sentinel_ptr, max_thoughts }
     }
 
     #[test]


### PR DESCRIPTION
## Description
Our previous reimplementations of ZTMarketingMgr, ZTMegatileMgr and ZTThoughtMgr were still reusing vanilla data structures. This PR expands the scope and reimplements more if the surrounding functions to allow fully replacing them with Rust data structures. Also reimplements ZTAwardMgr because I'm bad at splitting up PRs

## Proposed Changes
<!--- Break the change down a bit -->

## Checklist
 - [ ] Docs <!--- Paste Link Here -->
 - [x] Manually tested
 - [x] Unit tests (where possible) <!--- Usually on relevant for parsing or utility functions -->
